### PR TITLE
Swinging blade damage + reusable TrapDamage

### DIFF
--- a/Assets/Cainos/Pixel Art Platformer - Dungeon/Script/SwingingBladeTrap.cs
+++ b/Assets/Cainos/Pixel Art Platformer - Dungeon/Script/SwingingBladeTrap.cs
@@ -11,10 +11,6 @@ namespace Cainos.PixelArtPlatformer_Dungeon
         public float bladeRotationMaxAngle = 50.0f;
         public float bladeRotationTime = 3.0f;
 
-        [Header("Damage Settings")]
-        [Tooltip("Amount of damage dealt to the player on contact")]
-        public int damageAmount = 1;
-
         [Header("Objects")]
         public Transform blade;
 
@@ -29,28 +25,6 @@ namespace Cainos.PixelArtPlatformer_Dungeon
             v = bladeRotationCurve.Evaluate(timer / bladeRotationTime);
 
             blade.transform.localRotation = Quaternion.Euler(0.0f, 0.0f, v * bladeRotationMaxAngle);
-        }
-
-        private void OnTriggerEnter2D(Collider2D other)
-        {
-            // Check if the colliding object is the player
-            PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
-            if (playerHealth != null)
-            {
-                // Deal damage (negative value for damage)
-                playerHealth.ModifyHealth(-damageAmount);
-            }
-        }
-
-        private void OnCollisionEnter2D(Collision2D collision)
-        {
-            // Also check for regular collisions in case a Collider2D is used instead of a trigger
-            PlayerHealth playerHealth = collision.gameObject.GetComponent<PlayerHealth>();
-            if (playerHealth != null)
-            {
-                // Deal damage (negative value for damage)
-                playerHealth.ModifyHealth(-damageAmount);
-            }
         }
     }
 }

--- a/Assets/Cainos/Pixel Art Platformer - Dungeon/Script/SwingingBladeTrap.cs
+++ b/Assets/Cainos/Pixel Art Platformer - Dungeon/Script/SwingingBladeTrap.cs
@@ -11,6 +11,10 @@ namespace Cainos.PixelArtPlatformer_Dungeon
         public float bladeRotationMaxAngle = 50.0f;
         public float bladeRotationTime = 3.0f;
 
+        [Header("Damage Settings")]
+        [Tooltip("Amount of damage dealt to the player on contact")]
+        public int damageAmount = 1;
+
         [Header("Objects")]
         public Transform blade;
 
@@ -25,6 +29,28 @@ namespace Cainos.PixelArtPlatformer_Dungeon
             v = bladeRotationCurve.Evaluate(timer / bladeRotationTime);
 
             blade.transform.localRotation = Quaternion.Euler(0.0f, 0.0f, v * bladeRotationMaxAngle);
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            // Check if the colliding object is the player
+            PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
+            if (playerHealth != null)
+            {
+                // Deal damage (negative value for damage)
+                playerHealth.ModifyHealth(-damageAmount);
+            }
+        }
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            // Also check for regular collisions in case a Collider2D is used instead of a trigger
+            PlayerHealth playerHealth = collision.gameObject.GetComponent<PlayerHealth>();
+            if (playerHealth != null)
+            {
+                // Deal damage (negative value for damage)
+                playerHealth.ModifyHealth(-damageAmount);
+            }
         }
     }
 }

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -180,6 +180,38 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 49f36dbabf1417847a0c79bd4872e429, type: 3}
+--- !u!1 &1006784906 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 256754504867725843, guid: c749eb2aed7674224a923043109f15da, type: 3}
+  m_PrefabInstance: {fileID: 1624954046664414784}
+  m_PrefabAsset: {fileID: 0}
+--- !u!50 &1006784910
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006784906}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &1028870459
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -752,6 +784,10 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3816776619258052365, guid: c749eb2aed7674224a923043109f15da, type: 3}
+      propertyPath: m_IsTrigger
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4400244404320721172, guid: c749eb2aed7674224a923043109f15da, type: 3}
       propertyPath: m_Name
       value: Level_1
@@ -771,7 +807,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 256754504867725843, guid: c749eb2aed7674224a923043109f15da, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1006784910}
   m_SourcePrefab: {fileID: 100100000, guid: c749eb2aed7674224a923043109f15da, type: 3}
 --- !u!1001 &3212802410766754496
 PrefabInstance:

--- a/Assets/Scripts/TrapDamage.cs
+++ b/Assets/Scripts/TrapDamage.cs
@@ -1,30 +1,39 @@
 using UnityEngine;
 
+/// <summary>
+/// Reusable component: add to any hazard (blade, spikes, saw, etc.) to deal damage and optional knockback on contact.
+/// Works with both trigger and solid colliders.
+/// </summary>
 public class TrapDamage : MonoBehaviour
 {
     [Header("Settings")]
     public int damage = 1;
     public float knockbackForce = 5f;
 
-    private void OnTriggerEnter2D(Collider2D collision)
+    private void OnTriggerEnter2D(Collider2D other)
     {
-        // Check if the object we hit is the Player
-        if (collision.CompareTag("Player"))
-        {
-            // 1. Deal Damage
-            PlayerHealth playerHealth = collision.GetComponent<PlayerHealth>();
-            if (playerHealth != null)
-            {
-                playerHealth.ModifyHealth(-damage);
-            }
+        TryDamage(other.gameObject, other.transform.position);
+    }
 
-            // 2. Optional: Add Knockback
-            // This pushes the player away so they don't get hit twice instantly
-            Rigidbody2D playerRb = collision.GetComponent<Rigidbody2D>();
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        TryDamage(collision.gameObject, collision.transform.position);
+    }
+
+    private void TryDamage(GameObject other, Vector3 otherPosition)
+    {
+        if (!other.CompareTag("Player")) return;
+
+        PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
+        if (playerHealth != null)
+            playerHealth.ModifyHealth(-damage);
+
+        if (knockbackForce > 0f)
+        {
+            Rigidbody2D playerRb = other.GetComponent<Rigidbody2D>();
             if (playerRb != null)
             {
-                // Calculate direction from Blade -> Player
-                Vector2 direction = (collision.transform.position - transform.position).normalized;
+                Vector2 direction = (otherPosition - transform.position).normalized;
                 playerRb.AddForce(direction * knockbackForce, ForceMode2D.Impulse);
             }
         }


### PR DESCRIPTION
Swinging blade damage
Player takes damage when touching the swinging blade.
Blade still blocks the player (solid collision); no passing through.


https://github.com/user-attachments/assets/fc522dc6-a6a7-48a8-8984-9ffc8cea6e20


