### PR TITLE
Add DataCollectionService

### DIFF
--- a/Assets/Editor/DataCollectionEditor.cs
+++ b/Assets/Editor/DataCollectionEditor.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEngine;
+
+public static class DataCollectionEditor
+{
+    [MenuItem("Tools/Data Collection/Open data folder")]
+    public static void OpenDataFolder()
+    {
+        string path = Application.persistentDataPath;
+        EditorUtility.RevealInFinder(path);
+    }
+
+    [MenuItem("Tools/Data Collection/Log data folder path")]
+    public static void LogDataFolderPath()
+    {
+        string path = Application.persistentDataPath;
+        string filePath = System.IO.Path.Combine(path, "session_data.jsonl");
+        Debug.Log($"[DataCollection] Folder: {path}\nFile: {filePath}");
+    }
+}

--- a/Assets/Editor/DataCollectionEditor.cs.meta
+++ b/Assets/Editor/DataCollectionEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92e5d4d80d87fbd48a300808b39eb27b

--- a/Assets/Scripts/DataCollectionService.cs
+++ b/Assets/Scripts/DataCollectionService.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Central, lightweight data collector for player-behaviour features.
+/// Stores in-memory counters during play and flushes a single JSONL row per session
+/// to Application.persistentDataPath for offline analysis (e.g., Python/Scikit-Learn).
+/// </summary>
+public class DataCollectionService : MonoBehaviour
+{
+    public static DataCollectionService Instance { get; private set; }
+
+    [Header("Export Settings")]
+    [Tooltip("File name (within Application.persistentDataPath) for JSONL export.")]
+    [SerializeField] private string fileName = "session_data.jsonl";
+
+    [Tooltip("Log basic info when writing data to disk (including the file path).")]
+    [SerializeField] private bool enableDebugLogs = false;
+
+    /// <summary>Folder where session data is saved (Application.persistentDataPath).</summary>
+    public static string ExportFolderPath => Application.persistentDataPath;
+
+    /// <summary>Full path of the export file (uses configured fileName). Valid when Instance exists.</summary>
+    public string GetExportFilePath() => Path.Combine(Application.persistentDataPath, fileName);
+
+    /// <summary>Opens the folder where session data is saved in the system file manager (Explorer, Finder, etc.).</summary>
+    [ContextMenu("Open data folder in Explorer")]
+    public static void OpenExportFolder()
+    {
+        string path = Application.persistentDataPath;
+        if (!Directory.Exists(path))
+        {
+            UnityEngine.Debug.LogWarning($"[DataCollection] Folder does not exist yet: {path}. Play the game and quit once to create it.");
+            return;
+        }
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+        Process.Start("explorer.exe", $"\"{path}\"");
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+        Process.Start("open", $"\"{path}\"");
+#else
+        Process.Start(path);
+#endif
+        UnityEngine.Debug.Log($"[DataCollection] Opened folder: {path}");
+    }
+
+    // Session identity and timing
+    private string _sessionId;
+    private float _sessionStartTime;
+    private bool _sessionActive;
+
+    // Rewind timing
+    private bool _rewindInProgress;
+    private float _rewindStartTime;
+
+    // Movement
+    private int _dashCount;
+    private int _jumpCount;
+    private int _wallJumpCount;
+    private int _doubleJumpCount;
+    private int _rewindActivationCount;
+    private float _rewindDurationSeconds;
+
+    // Combat
+    private int _meleeAttacks;
+    private int _meleeHits;
+    private int _spellCasts;
+    private int _spellHits;
+    private int _rainAttackUses;
+
+    // Health / deaths
+    private int _damageTakenTotal;
+    private int _deathCount;
+
+    // Interaction
+    private int _doorsEntered;
+    private int _trapHits;
+    private int _tutorialStepsCompleted;
+    private int _pauseCount;
+
+    private bool _isPrimaryInstance;
+
+    [Serializable]
+    private class SessionDataRecord
+    {
+        public string session_id;
+        public float session_duration_seconds;
+
+        public int dash_count;
+        public int jump_count;
+        public int wall_jump_count;
+        public int double_jump_count;
+        public int rewind_activation_count;
+        public float rewind_duration_seconds;
+
+        public int melee_attacks;
+        public int melee_hits;
+        public int spell_casts;
+        public int spell_hits;
+        public int rain_attack_uses;
+
+        public int damage_taken_total;
+        public int death_count;
+
+        public int doors_entered;
+        public int trap_hits;
+        public int tutorial_steps_completed;
+        public int pause_count;
+
+        // Filled after clustering (left empty in-game)
+        public string persona_label;
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            // Secondary instance: destroy without flushing.
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        _isPrimaryInstance = true;
+        DontDestroyOnLoad(gameObject);
+
+        _sessionId = Guid.NewGuid().ToString();
+        _sessionStartTime = Time.unscaledTime;
+        _sessionActive = true;
+
+        if (enableDebugLogs)
+            UnityEngine.Debug.Log($"[DataCollection] Session started. Data will be written to: {GetExportFilePath()}");
+    }
+
+    private void OnApplicationQuit()
+    {
+        FlushSessionIfNeeded();
+    }
+
+    private void OnDisable()
+    {
+        FlushSessionIfNeeded();
+    }
+
+    #region Public recording API
+
+    // Movement
+    public void RecordDash()
+    {
+        if (!_sessionActive) return;
+        _dashCount++;
+    }
+
+    /// <summary>
+    /// Records a jump. Flags can be used to distinguish wall and double jumps.
+    /// </summary>
+    public void RecordJump(bool isWallJump, bool usedDoubleJump)
+    {
+        if (!_sessionActive) return;
+        _jumpCount++;
+        if (isWallJump) _wallJumpCount++;
+        if (usedDoubleJump) _doubleJumpCount++;
+    }
+
+    // Rewind
+    public void RecordRewindStarted()
+    {
+        if (!_sessionActive) return;
+        _rewindActivationCount++;
+        if (!_rewindInProgress)
+        {
+            _rewindInProgress = true;
+            _rewindStartTime = Time.unscaledTime;
+        }
+    }
+
+    public void RecordRewindStopped()
+    {
+        if (!_sessionActive) return;
+        if (_rewindInProgress)
+        {
+            float delta = Time.unscaledTime - _rewindStartTime;
+            if (delta > 0f)
+            {
+                _rewindDurationSeconds += delta;
+            }
+            _rewindInProgress = false;
+        }
+    }
+
+    // Combat
+    public void RecordMeleeAttempt()
+    {
+        if (!_sessionActive) return;
+        _meleeAttacks++;
+    }
+
+    public void RecordMeleeHit()
+    {
+        if (!_sessionActive) return;
+        _meleeHits++;
+    }
+
+    public void RecordSpellCast()
+    {
+        if (!_sessionActive) return;
+        _spellCasts++;
+    }
+
+    public void RecordSpellHit()
+    {
+        if (!_sessionActive) return;
+        _spellHits++;
+    }
+
+    public void RecordRainAttackUse()
+    {
+        if (!_sessionActive) return;
+        _rainAttackUses++;
+    }
+
+    // Health / deaths
+    public void RecordDamageTaken(int amount)
+    {
+        if (!_sessionActive) return;
+        if (amount <= 0) return;
+        _damageTakenTotal += amount;
+    }
+
+    public void RecordDeath()
+    {
+        if (!_sessionActive) return;
+        _deathCount++;
+    }
+
+    // Interaction
+    public void RecordDoorEntered(string sceneName)
+    {
+        if (!_sessionActive) return;
+        _doorsEntered++;
+    }
+
+    public void RecordTrapHit()
+    {
+        if (!_sessionActive) return;
+        _trapHits++;
+    }
+
+    public void RecordTutorialStepCompleted()
+    {
+        if (!_sessionActive) return;
+        _tutorialStepsCompleted++;
+    }
+
+    public void RecordPause()
+    {
+        if (!_sessionActive) return;
+        _pauseCount++;
+    }
+
+    /// <summary>
+    /// Writes the current session to file immediately, then starts a new session (e.g. call when player passes through a door).
+    /// Use this so data is saved before a scene load or other transition.
+    /// </summary>
+    public void SaveSessionAndStartNew()
+    {
+        if (!_isPrimaryInstance) return;
+        if (!_sessionActive) return;
+        WriteCurrentSessionToFile();
+        StartNewSession();
+    }
+
+    #endregion
+
+    #region Internal helpers
+
+    private void WriteCurrentSessionToFile()
+    {
+        if (!_isPrimaryInstance) return;
+
+        var record = new SessionDataRecord
+        {
+            session_id = _sessionId,
+            session_duration_seconds = Mathf.Max(0f, Time.unscaledTime - _sessionStartTime),
+
+            dash_count = _dashCount,
+            jump_count = _jumpCount,
+            wall_jump_count = _wallJumpCount,
+            double_jump_count = _doubleJumpCount,
+            rewind_activation_count = _rewindActivationCount,
+            rewind_duration_seconds = _rewindDurationSeconds,
+
+            melee_attacks = _meleeAttacks,
+            melee_hits = _meleeHits,
+            spell_casts = _spellCasts,
+            spell_hits = _spellHits,
+            rain_attack_uses = _rainAttackUses,
+
+            damage_taken_total = _damageTakenTotal,
+            death_count = _deathCount,
+
+            doors_entered = _doorsEntered,
+            trap_hits = _trapHits,
+            tutorial_steps_completed = _tutorialStepsCompleted,
+            pause_count = _pauseCount,
+
+            persona_label = string.Empty
+        };
+
+        string json = JsonUtility.ToJson(record);
+
+        try
+        {
+            string path = Path.Combine(Application.persistentDataPath, fileName);
+            File.AppendAllText(path, json + Environment.NewLine);
+            if (enableDebugLogs)
+            {
+                UnityEngine.Debug.Log($"[DataCollection] Wrote session data to: {path}");
+            }
+        }
+        catch (Exception ex)
+        {
+            if (enableDebugLogs)
+            {
+                UnityEngine.Debug.LogWarning($"[DataCollection] Failed to write data: {ex.Message}");
+            }
+        }
+    }
+
+    private void StartNewSession()
+    {
+        _sessionId = Guid.NewGuid().ToString();
+        _sessionStartTime = Time.unscaledTime;
+
+        _dashCount = 0;
+        _jumpCount = 0;
+        _wallJumpCount = 0;
+        _doubleJumpCount = 0;
+        _rewindActivationCount = 0;
+        _rewindDurationSeconds = 0f;
+        _rewindInProgress = false;
+
+        _meleeAttacks = 0;
+        _meleeHits = 0;
+        _spellCasts = 0;
+        _spellHits = 0;
+        _rainAttackUses = 0;
+
+        _damageTakenTotal = 0;
+        _deathCount = 0;
+
+        _doorsEntered = 0;
+        _trapHits = 0;
+        _tutorialStepsCompleted = 0;
+        _pauseCount = 0;
+
+        if (enableDebugLogs)
+            UnityEngine.Debug.Log($"[DataCollection] New session started. Data will be written to: {GetExportFilePath()}");
+    }
+
+    private void FlushSessionIfNeeded()
+    {
+        if (!_isPrimaryInstance) return;
+        if (!_sessionActive) return;
+
+        _sessionActive = false;
+        WriteCurrentSessionToFile();
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/DataCollectionService.cs.meta
+++ b/Assets/Scripts/DataCollectionService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a530d08c7952b794da298fad7b264566

--- a/Assets/Scripts/DoorSceneLoader.cs
+++ b/Assets/Scripts/DoorSceneLoader.cs
@@ -16,6 +16,8 @@ public class DoorSceneLoader : MonoBehaviour
     {
         if (other.CompareTag("Player"))
         {
+            DataCollectionService.Instance?.RecordDoorEntered(sceneName);
+            DataCollectionService.Instance?.SaveSessionAndStartNew();
             animator.SetBool("IsOpened", true);
             StartCoroutine(Transition(other.gameObject));
         }

--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -16,6 +16,10 @@ public class PauseMenu : MonoBehaviour
             container.SetActive(isPaused);
             Time.timeScale = isPaused ? 0f : 1f;
             escapePressed += 1; 
+            if (isPaused)
+            {
+                DataCollectionService.Instance?.RecordPause();
+            }
         }
     }
 
@@ -25,6 +29,7 @@ public class PauseMenu : MonoBehaviour
         container.SetActive(true);
         Time.timeScale = 0f;    
         isPaused = true; 
+        DataCollectionService.Instance?.RecordPause();
     }
 
     public void ResumeButton()

--- a/Assets/Scripts/PlayerCombat.cs
+++ b/Assets/Scripts/PlayerCombat.cs
@@ -76,7 +76,7 @@ public class PlayerCombat : MonoBehaviour
 
     private void PerformMelee()
     {
-
+        DataCollectionService.Instance?.RecordMeleeAttempt();
         if (Time.time - lastAttackTime > comboResetTime)
         {
             comboStep = 0;
@@ -167,6 +167,7 @@ public class PlayerCombat : MonoBehaviour
             {
                 hitAnything = true;
                 target.TakeDamage(meleeDamage);
+                DataCollectionService.Instance?.RecordMeleeHit();
                 if (manaSystem != null) manaSystem.AddManaOnHit();
 
                 // 3. PHYSICS INTERACTION (The Pogo)

--- a/Assets/Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerHealth.cs
@@ -81,6 +81,7 @@ public class PlayerHealth : MonoBehaviour, IRewindable
             if (isInvincible) return;
 
             // Otherwise, take the damage and start invincibility
+            DataCollectionService.Instance?.RecordDamageTaken(-amount);
             TakeDamage(amount);
         }
         
@@ -192,6 +193,8 @@ public class PlayerHealth : MonoBehaviour, IRewindable
     {   
         if (IsDead) return; 
         IsDead = true;
+        OnDeath?.Invoke();
+        DataCollectionService.Instance?.RecordDeath();
         Debug.Log("Player Died");
 
         StartCoroutine(HandleDeath()); 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -303,7 +303,9 @@ public class PlayerPlatformer : MonoBehaviour
 
         rb.linearVelocity = new Vector2(rb.linearVelocity.x, jumpForce);
         isGrounded = false;
-    
+
+        bool usedDoubleJump = extraJumpsRemaining > 0;
+        DataCollectionService.Instance?.RecordJump(false, usedDoubleJump);
 
         yield return null;
 
@@ -387,6 +389,7 @@ public class PlayerPlatformer : MonoBehaviour
         rb.linearVelocity = new Vector2(jumpDirection * wallJumpPower.x, wallJumpPower.y);
 
         if (anim != null) anim.SetTrigger("Jump"); // Or "WallJump" if you have it
+        DataCollectionService.Instance?.RecordJump(true, false);
     
         yield return new WaitForSeconds(wallJumpDuration);    
         isWallJumping = false;
@@ -398,6 +401,7 @@ public class PlayerPlatformer : MonoBehaviour
         canDash = false;
 
         tutorialManager?.OnPlayerDash();
+        DataCollectionService.Instance?.RecordDash();
 
         if (anim != null) 
         {

--- a/Assets/Scripts/Playerblastspell.cs
+++ b/Assets/Scripts/Playerblastspell.cs
@@ -77,6 +77,7 @@ public class PlayerSpellSystem : MonoBehaviour, IRewindable
             {
                 CastSpell();
                 nextFireTime = Time.time + cooldown;
+                DataCollectionService.Instance?.RecordSpellCast();
             }
             else 
             {

--- a/Assets/Scripts/SpellProjectile.cs
+++ b/Assets/Scripts/SpellProjectile.cs
@@ -83,6 +83,7 @@ public class SpellProjectile : MonoBehaviour, IRewindable
         if (dmg != null)
         {
             dmg.TakeDamage(damage);
+            DataCollectionService.Instance?.RecordSpellHit();
 
             IKnockbackable kb = collision.GetComponent<IKnockbackable>();
             if (kb != null)

--- a/Assets/Scripts/TimeRewind/Player/PlayerRewindController.cs
+++ b/Assets/Scripts/TimeRewind/Player/PlayerRewindController.cs
@@ -117,6 +117,7 @@ namespace TimeRewind
         public void OnStartRewind()
         {
             _isRewinding = true;
+            DataCollectionService.Instance?.RecordRewindStarted();
             OnRewindStarted?.Invoke();
             _originalBodyType = _rb.bodyType;
             _rb.bodyType = RigidbodyType2D.Kinematic;
@@ -128,6 +129,7 @@ namespace TimeRewind
         public void OnStopRewind()
         {
             _isRewinding = false;
+            DataCollectionService.Instance?.RecordRewindStopped();
             OnRewindStopped?.Invoke();
             _rb.bodyType = _originalBodyType;
             

--- a/Assets/Scripts/TrapDamage.cs
+++ b/Assets/Scripts/TrapDamage.cs
@@ -26,7 +26,10 @@ public class TrapDamage : MonoBehaviour
         
         PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
         if (playerHealth != null)
+        {
             playerHealth.ModifyHealth(-damage);
+            DataCollectionService.Instance?.RecordTrapHit();
+        }
 
         if (knockbackForce > 0f)
         {

--- a/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -366,6 +366,7 @@ public class TutorialManager : MonoBehaviour
             spellCompleted = true; 
             HideHint(spellHint);
             Debug.Log("Player spell tutorial completed");
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         }
     }
     
@@ -376,6 +377,7 @@ public class TutorialManager : MonoBehaviour
             attackCompleted = true;
             HideHint(attackHint);
             Debug.Log("Player attack tutorial complete");
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         }
     }
 
@@ -386,6 +388,7 @@ public class TutorialManager : MonoBehaviour
             jumpCompleted = true;
             HideHint(jumpHint);
             Debug.Log("Player jump tutorial complete");
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         }
     }
 
@@ -397,6 +400,7 @@ public class TutorialManager : MonoBehaviour
             rewindFollow.enabled = false;
             HideHint(rewindHint);
             Debug.Log("Player rewind tutorial complete");
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         }
     }
 
@@ -407,6 +411,7 @@ public class TutorialManager : MonoBehaviour
             dashCompleted = true;
             HideHint(dashHint);
             Debug.Log("Player dash tutorial completed"); 
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         } 
     }
 
@@ -417,6 +422,7 @@ public class TutorialManager : MonoBehaviour
             wallJumpCompleted = true; 
             HideHint(wallJumpHint); 
             Debug.Log("Player wall jump tutorial completed"); 
+            DataCollectionService.Instance?.RecordTutorialStepCompleted();
         }
     }
 


### PR DESCRIPTION
# Data Collection

## Scene Setup
- [ ] A GameObject with `DataCollectionService` exists in the first scene the player plays (e.g. `GameScene`).  
      Without it, no data is collected or written.

---

## In-Game (Data Is Recorded)

### Movement
- [ ] Dash a few times → Stop Play → Check one session row has `dash_count > 0`.
- [ ] Repeat for jumps:
  - [ ] Normal jump → `jump_count > 0`
  - [ ] Double jump → `double_jump_count > 0`
  - [ ] Wall jump → `wall_jump_count > 0`

### Rewind
- [ ] Use rewind (R or triggers), then Stop Play →  
      Row has:
  - `rewind_activation_count ≥ 1`
  - `rewind_duration_seconds > 0`

### Combat
- [ ] Perform melee attacks (some hits, some misses) →  
      Row has:
  - `melee_attacks > 0`
  - `melee_hits > 0`
- [ ] Cast spells and hit an enemy →  
      - `spell_casts > 0`
      - `spell_hits > 0`

### Health
- [ ] Take damage (trap or enemy) → `damage_taken_total` increases.
- [ ] Die → `death_count` increases.

### Interaction
- [ ] Enter a door → counter increases.
- [ ] Hit a trap → counter increases.
- [ ] Pause → counter increases.
- [ ] Complete tutorial steps → counter increases.
      (Check next or same row depending on when data flushes.
      
      
      
  recorded data
      
   session_id
session_duration_seconds
persona_label
dash_count
jump_count
wall_jump_count
double_jump_count
rewind_activation_count
rewind_duration_seconds
melee_attacks
melee_hits
spell_casts
spell_hits
rain_attack_uses
damage_taken_total
death_count
doors_entered
trap_hits
tutorial_steps_completed
pause_count