### PR TITLE
Added Ghost and Skeleton warrior enemies

### DIFF
--- a/Assets/Animations/MeleeSkeleton.controller
+++ b/Assets/Animations/MeleeSkeleton.controller
@@ -1,5 +1,62 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-8756377432134697405
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 3681637234298572493}
+    m_Position: {x: 299.3333, y: 105.33334, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4677200806558405271}
+    m_Position: {x: 250.00002, y: 260.66666, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 6423558192989416556}
+    m_Position: {x: 549.3333, y: 384, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7211725122008381867}
+    m_Position: {x: 844.6667, y: 432, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 3681637234298572493}
+--- !u!1102 &-7211725122008381867
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -8,5 +65,113 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: MeleeSkeleton
   serializedVersion: 5
-  m_AnimatorParameters: []
-  m_AnimatorLayers: []
+  m_AnimatorParameters:
+  - m_Name: isRunning
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Die
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -8756377432134697405}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &3681637234298572493
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &4677200806558405271
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Die
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &6423558192989416556
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Animations/MeleeSkeleton.controller
+++ b/Assets/Animations/MeleeSkeleton.controller
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MeleeSkeleton
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers: []

--- a/Assets/Animations/MeleeSkeleton.controller.meta
+++ b/Assets/Animations/MeleeSkeleton.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c87bfcbd911655947a8531a44ccc6d7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemies/Standard/GhostEnemy.prefab
+++ b/Assets/Prefabs/Enemies/Standard/GhostEnemy.prefab
@@ -1,0 +1,225 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &792851248633016917
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1255838054294113718}
+  - component: {fileID: 874748711114247386}
+  - component: {fileID: 987323167111619277}
+  - component: {fileID: 8060149661176849044}
+  - component: {fileID: 2208035217881589895}
+  - component: {fileID: 5275606794825206045}
+  - component: {fileID: 1048562369388960493}
+  m_Layer: 0
+  m_Name: GhostEnemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1255838054294113718
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -23.86, y: -12.3, z: 0}
+  m_LocalScale: {x: 3.6713, y: 4.2967, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &874748711114247386
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: -5662871578180991815, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.1, y: 0.8}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!50 &987323167111619277
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!70 &8060149661176849044
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0.007069514, y: -0.03324676}
+  m_Size: {x: 0.20345247, y: 0.45057344}
+  m_Direction: 0
+--- !u!114 &2208035217881589895
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f2ea977a7cd7344deb9715d8b8c6e82d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: NewAssembly::HitFlash
+  flashColor: {r: 1, g: 0, b: 0, a: 1}
+  flashDuration: 0.1
+--- !u!114 &5275606794825206045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e82b44244b53e84e941b62a4868e0e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: NewAssembly::GhostEnemy
+  health: 3
+  knockbackResistance: 1
+  knockbackUpMultiplier: 0.8
+  deathAnimationDuration: 0.6
+  detectionRange: 7
+  moveSpeed: 2
+  attackCooldown: 1
+  damage: 1
+  hoverAmplitude: 0.3
+  hoverFrequency: 1.5
+  teleportInterval: 5
+  teleportOffset: 2
+  phaseOutDuration: 1
+  phaseInDuration: 1
+  player: {fileID: 0}
+--- !u!95 &1048562369388960493
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792851248633016917}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: fc4cd9170ee6bc0479c82252de781bfc, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Assets/Prefabs/Enemies/Standard/GhostEnemy.prefab.meta
+++ b/Assets/Prefabs/Enemies/Standard/GhostEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea3d597bae199ef4bba7019ce135659e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemies/Standard/SkeletonWarrior.prefab
+++ b/Assets/Prefabs/Enemies/Standard/SkeletonWarrior.prefab
@@ -1,0 +1,222 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1239436902015136738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1483419064559744378}
+  - component: {fileID: 1689688445223640031}
+  - component: {fileID: 7196429899434338361}
+  - component: {fileID: 9146663691717770187}
+  - component: {fileID: 3878115214501292766}
+  - component: {fileID: 853483887166070529}
+  - component: {fileID: 8597023694846177901}
+  m_Layer: 0
+  m_Name: SkeletonWarrior
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1483419064559744378
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -19.79, y: -12.46, z: 0}
+  m_LocalScale: {x: 2.973381, y: 3.6251152, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1689688445223640031
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: -3828820476789506080, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.1, y: 0.8}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!50 &7196429899434338361
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &9146663691717770187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f2ea977a7cd7344deb9715d8b8c6e82d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: NewAssembly::HitFlash
+  flashColor: {r: 1, g: 0, b: 0, a: 1}
+  flashDuration: 0.1
+--- !u!114 &3878115214501292766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27ce4def3b3ed0a408851d92721b9cda, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: NewAssembly::MeleeSkeleton
+  health: 10
+  knockbackResistance: 1
+  knockbackUpMultiplier: 0.8
+  deathAnimationDuration: 1
+  detectionRange: 6
+  attackRange: 1.2
+  moveSpeed: 2.5
+  attackCooldown: 1.2
+  damage: 1
+  hitboxRadius: 0.6
+  hitboxOffset: 0.8
+  player: {fileID: 0}
+--- !u!70 &853483887166070529
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -0.005212944, y: -0.025651578}
+  m_Size: {x: 0.21389396, y: 0.43480694}
+  m_Direction: 0
+--- !u!95 &8597023694846177901
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1239436902015136738}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: f0222d30a0182ba4e84733b277413808, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Assets/Prefabs/Enemies/Standard/SkeletonWarrior.prefab.meta
+++ b/Assets/Prefabs/Enemies/Standard/SkeletonWarrior.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 675e0291407d91841aaf63cd35ccdcaa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemyLogic/EnemyBase.cs
+++ b/Assets/Scripts/EnemyLogic/EnemyBase.cs
@@ -115,6 +115,11 @@ public class EnemyBase : MonoBehaviour, IDamageable, IKnockbackable, IRewindable
     {
         isRewinding = false;
         rb.bodyType = originalBodyType;
+
+        // If rewind stopped during a death animation, restart the cleanup coroutine
+        // so the sprite gets hidden (StopAllCoroutines in OnStartRewind killed it)
+        if (wasDead)
+            StartCoroutine(DeathRoutine());
     }
 
 

--- a/Assets/Scripts/EnemyLogic/GhostEnemy.cs
+++ b/Assets/Scripts/EnemyLogic/GhostEnemy.cs
@@ -202,6 +202,7 @@ public class GhostEnemy : EnemyBase
         state.SetCustomData("isTeleporting", isTeleporting);
         state.SetCustomData("lastTeleportTime", lastTeleportTime);
         state.SetCustomData("colEnabled", col != null && col.enabled);
+        state.SetCustomData("spriteEnabled", sprite != null && sprite.enabled);
 
         if (animator != null)
         {
@@ -222,6 +223,9 @@ public class GhostEnemy : EnemyBase
 
         if (col != null)
             col.enabled = state.GetCustomData<bool>("colEnabled", true);
+
+        if (sprite != null)
+            sprite.enabled = state.GetCustomData<bool>("spriteEnabled", true);
 
         if (animator != null)
             animator.Play(state.AnimatorStateHash, 0, state.AnimatorNormalizedTime);

--- a/Assets/Scripts/EnemyLogic/GhostEnemy.cs
+++ b/Assets/Scripts/EnemyLogic/GhostEnemy.cs
@@ -17,6 +17,7 @@ public class GhostEnemy : EnemyBase
     [Header("Teleport")]
     public float teleportInterval = 3f;
     public float teleportOffset = 2f;     // how far from player to reappear
+    public float teleportYOffset = 1f;    // raise spawn point above ground surface
     public float phaseOutDuration = 0.5f; // match your PhaseOut clip length
     public float phaseInDuration = 0.5f;  // match your PhaseIn clip length
 
@@ -120,7 +121,9 @@ public class GhostEnemy : EnemyBase
         float side = Random.value > 0.5f ? 1f : -1f;
         Vector2 targetX = (Vector2)player.position + new Vector2(side * teleportOffset, 1f);
         RaycastHit2D hit = Physics2D.Raycast(targetX, Vector2.down, 10f, LayerMask.GetMask("Ground"));
-        Vector2 spawnPos = hit.collider != null ? hit.point : (Vector2)player.position + new Vector2(side * teleportOffset, 0f);
+        Vector2 spawnPos = hit.collider != null
+            ? hit.point + Vector2.up * teleportYOffset
+            : (Vector2)player.position + new Vector2(side * teleportOffset, teleportYOffset);
         transform.position = spawnPos;
 
         // Phase in

--- a/Assets/Scripts/EnemyLogic/GhostEnemy.cs
+++ b/Assets/Scripts/EnemyLogic/GhostEnemy.cs
@@ -14,16 +14,22 @@ public class GhostEnemy : EnemyBase
     public float hoverAmplitude = 0.3f;
     public float hoverFrequency = 1.5f;
 
-    [Header("Phase-in")]
-    public float phaseInDuration = 0.6f; // Fade in when first detecting player
+    [Header("Teleport")]
+    public float teleportInterval = 3f;
+    public float teleportOffset = 2f;     // how far from player to reappear
+    public float phaseOutDuration = 0.5f; // match your PhaseOut clip length
+    public float phaseInDuration = 0.5f;  // match your PhaseIn clip length
 
     public Transform player;
 
     private Animator animator;
+    private Collider2D col;
     private float lastAttackTime;
+    private float lastTeleportTime;
     private bool isTouchingPlayer;
     private bool hasDetected;
     private bool isHitStunned;
+    private bool isTeleporting;
 
     private enum State { Idle, Chase, Attack }
     private State currentState = State.Idle;
@@ -37,14 +43,14 @@ public class GhostEnemy : EnemyBase
     void Start()
     {
         animator = GetComponent<Animator>();
-        // Ghosts float — no gravity
+        col = GetComponent<Collider2D>();
         rb.gravityScale = 0f;
         rb.constraints = RigidbodyConstraints2D.FreezeRotation;
     }
 
     void Update()
     {
-        if (isRewinding || wasDead) return;
+        if (isRewinding || wasDead || isTeleporting) return;
         if (player == null) return;
 
         float dist = Vector2.Distance(transform.position, player.position);
@@ -53,11 +59,7 @@ public class GhostEnemy : EnemyBase
             currentState = State.Attack;
         else if (dist < detectionRange)
         {
-            if (!hasDetected)
-            {
-                hasDetected = true;
-                StartCoroutine(PhaseInRoutine());
-            }
+            hasDetected = true;
             currentState = State.Chase;
         }
         else
@@ -74,7 +76,7 @@ public class GhostEnemy : EnemyBase
 
     void FixedUpdate()
     {
-        if (isRewinding || wasDead || isHitStunned) return;
+        if (isRewinding || wasDead || isHitStunned || isTeleporting) return;
 
         switch (currentState)
         {
@@ -83,6 +85,11 @@ public class GhostEnemy : EnemyBase
                 break;
 
             case State.Chase:
+                if (Time.time >= lastTeleportTime + teleportInterval)
+                {
+                    StartCoroutine(TeleportRoutine());
+                    break;
+                }
                 Vector2 dir = ((Vector2)player.position - (Vector2)transform.position).normalized;
                 rb.linearVelocity = dir * moveSpeed;
                 break;
@@ -93,30 +100,36 @@ public class GhostEnemy : EnemyBase
                 {
                     lastAttackTime = Time.time;
                     animator?.SetTrigger("Attack");
-                    player.GetComponent<PlayerHealth>()?.ModifyHealth(-damage);
                 }
                 break;
         }
     }
 
-    // Fade in from transparent when the ghost detects the player
-    IEnumerator PhaseInRoutine()
+    // Fade out → teleport near player → fade in
+    IEnumerator TeleportRoutine()
     {
-        Color c = sprite.color;
-        c.a = 0f;
-        sprite.color = c;
+        isTeleporting = true;
+        rb.linearVelocity = Vector2.zero;
+        if (col != null) col.enabled = false;
 
-        float elapsed = 0f;
-        while (elapsed < phaseInDuration)
-        {
-            elapsed += Time.deltaTime;
-            c.a = Mathf.Clamp01(elapsed / phaseInDuration);
-            sprite.color = c;
-            yield return null;
-        }
+        // Phase out — ghost sinks underground
+        animator?.SetTrigger("PhaseOut");
+        yield return new WaitForSeconds(phaseOutDuration);
 
-        c.a = 1f;
-        sprite.color = c;
+        // Ghost is now underground in the animation — safe to snap position
+        float side = Random.value > 0.5f ? 1f : -1f;
+        Vector2 targetX = (Vector2)player.position + new Vector2(side * teleportOffset, 1f);
+        RaycastHit2D hit = Physics2D.Raycast(targetX, Vector2.down, 10f, LayerMask.GetMask("Ground"));
+        Vector2 spawnPos = hit.collider != null ? hit.point : (Vector2)player.position + new Vector2(side * teleportOffset, 0f);
+        transform.position = spawnPos;
+
+        // Phase in
+        animator?.SetTrigger("PhaseIn");
+        yield return new WaitForSeconds(phaseInDuration);
+
+        if (col != null) col.enabled = true;
+        isTeleporting = false;
+        lastTeleportTime = Time.time;
     }
 
     public override void TakeDamage(int amount)
@@ -132,6 +145,13 @@ public class GhostEnemy : EnemyBase
         isHitStunned = true;
         yield return new WaitForSeconds(0.2f);
         isHitStunned = false;
+    }
+
+    // Called by Animation Event on the attack clip at the hit frame
+    public void GhostDealDamage()
+    {
+        if (wasDead || isRewinding || !isTouchingPlayer || player == null) return;
+        player.GetComponent<PlayerHealth>()?.ModifyHealth(-damage);
     }
 
     void OnCollisionEnter2D(Collision2D collision)
@@ -154,7 +174,6 @@ public class GhostEnemy : EnemyBase
         animator?.SetTrigger("Die");
         rb.linearVelocity = Vector2.zero;
 
-        Collider2D col = GetComponent<Collider2D>();
         if (col != null) col.enabled = false;
 
         StartCoroutine(base.DeathRoutine());
@@ -167,6 +186,8 @@ public class GhostEnemy : EnemyBase
         base.OnStartRewind();
         StopAllCoroutines();
         isTouchingPlayer = false;
+        isTeleporting = false;
+        if (col != null) col.enabled = true;
     }
 
     public override void OnStopRewind()
@@ -178,7 +199,17 @@ public class GhostEnemy : EnemyBase
     {
         var state = base.CaptureState();
         state.SetCustomData("hasDetected", hasDetected);
-        state.SetCustomData("spriteAlpha", sprite.color.a);
+        state.SetCustomData("isTeleporting", isTeleporting);
+        state.SetCustomData("lastTeleportTime", lastTeleportTime);
+        state.SetCustomData("colEnabled", col != null && col.enabled);
+
+        if (animator != null)
+        {
+            AnimatorStateInfo info = animator.GetCurrentAnimatorStateInfo(0);
+            state.AnimatorStateHash = info.shortNameHash;
+            state.AnimatorNormalizedTime = info.normalizedTime;
+        }
+
         return state;
     }
 
@@ -186,9 +217,13 @@ public class GhostEnemy : EnemyBase
     {
         base.ApplyState(state);
         hasDetected = state.GetCustomData<bool>("hasDetected");
+        isTeleporting = state.GetCustomData<bool>("isTeleporting");
+        lastTeleportTime = state.GetCustomData<float>("lastTeleportTime");
 
-        Color c = sprite.color;
-        c.a = state.GetCustomData<float>("spriteAlpha");
-        sprite.color = c;
+        if (col != null)
+            col.enabled = state.GetCustomData<bool>("colEnabled", true);
+
+        if (animator != null)
+            animator.Play(state.AnimatorStateHash, 0, state.AnimatorNormalizedTime);
     }
 }

--- a/Assets/Scripts/EnemyLogic/GhostEnemy.cs
+++ b/Assets/Scripts/EnemyLogic/GhostEnemy.cs
@@ -1,0 +1,194 @@
+using UnityEngine;
+using System.Collections;
+using TimeRewind;
+
+public class GhostEnemy : EnemyBase
+{
+    [Header("Stats")]
+    public float detectionRange = 7f;
+    public float moveSpeed = 2f;
+    public float attackCooldown = 1f;
+    public int damage = 1;
+
+    [Header("Hover")]
+    public float hoverAmplitude = 0.3f;
+    public float hoverFrequency = 1.5f;
+
+    [Header("Phase-in")]
+    public float phaseInDuration = 0.6f; // Fade in when first detecting player
+
+    public Transform player;
+
+    private Animator animator;
+    private float lastAttackTime;
+    private bool isTouchingPlayer;
+    private bool hasDetected;
+    private bool isHitStunned;
+
+    private enum State { Idle, Chase, Attack }
+    private State currentState = State.Idle;
+
+    protected override void Awake()
+    {
+        health = 2;
+        base.Awake();
+    }
+
+    void Start()
+    {
+        animator = GetComponent<Animator>();
+        // Ghosts float — no gravity
+        rb.gravityScale = 0f;
+        rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+    }
+
+    void Update()
+    {
+        if (isRewinding || wasDead) return;
+        if (player == null) return;
+
+        float dist = Vector2.Distance(transform.position, player.position);
+
+        if (isTouchingPlayer)
+            currentState = State.Attack;
+        else if (dist < detectionRange)
+        {
+            if (!hasDetected)
+            {
+                hasDetected = true;
+                StartCoroutine(PhaseInRoutine());
+            }
+            currentState = State.Chase;
+        }
+        else
+            currentState = State.Idle;
+
+        // Face player
+        if (player.position.x > transform.position.x)
+            sprite.flipX = false;
+        else
+            sprite.flipX = true;
+
+        animator?.SetBool("isChasing", currentState == State.Chase);
+    }
+
+    void FixedUpdate()
+    {
+        if (isRewinding || wasDead || isHitStunned) return;
+
+        switch (currentState)
+        {
+            case State.Idle:
+                rb.linearVelocity = new Vector2(0, Mathf.Sin(Time.time * hoverFrequency) * hoverAmplitude);
+                break;
+
+            case State.Chase:
+                Vector2 dir = ((Vector2)player.position - (Vector2)transform.position).normalized;
+                rb.linearVelocity = dir * moveSpeed;
+                break;
+
+            case State.Attack:
+                rb.linearVelocity = Vector2.zero;
+                if (Time.time >= lastAttackTime + attackCooldown)
+                {
+                    lastAttackTime = Time.time;
+                    animator?.SetTrigger("Attack");
+                    player.GetComponent<PlayerHealth>()?.ModifyHealth(-damage);
+                }
+                break;
+        }
+    }
+
+    // Fade in from transparent when the ghost detects the player
+    IEnumerator PhaseInRoutine()
+    {
+        Color c = sprite.color;
+        c.a = 0f;
+        sprite.color = c;
+
+        float elapsed = 0f;
+        while (elapsed < phaseInDuration)
+        {
+            elapsed += Time.deltaTime;
+            c.a = Mathf.Clamp01(elapsed / phaseInDuration);
+            sprite.color = c;
+            yield return null;
+        }
+
+        c.a = 1f;
+        sprite.color = c;
+    }
+
+    public override void TakeDamage(int amount)
+    {
+        if (wasDead) return;
+        animator?.SetTrigger("Hit");
+        StartCoroutine(HitStunRoutine());
+        base.TakeDamage(amount);
+    }
+
+    IEnumerator HitStunRoutine()
+    {
+        isHitStunned = true;
+        yield return new WaitForSeconds(0.2f);
+        isHitStunned = false;
+    }
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("Player"))
+            isTouchingPlayer = true;
+    }
+
+    void OnCollisionExit2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("Player"))
+            isTouchingPlayer = false;
+    }
+
+    public override void Die()
+    {
+        wasDead = true;
+        StopAllCoroutines();
+
+        animator?.SetTrigger("Die");
+        rb.linearVelocity = Vector2.zero;
+
+        Collider2D col = GetComponent<Collider2D>();
+        if (col != null) col.enabled = false;
+
+        StartCoroutine(base.DeathRoutine());
+    }
+
+    // ================= REWIND =================
+
+    public override void OnStartRewind()
+    {
+        base.OnStartRewind();
+        StopAllCoroutines();
+        isTouchingPlayer = false;
+    }
+
+    public override void OnStopRewind()
+    {
+        base.OnStopRewind();
+    }
+
+    public override RewindState CaptureState()
+    {
+        var state = base.CaptureState();
+        state.SetCustomData("hasDetected", hasDetected);
+        state.SetCustomData("spriteAlpha", sprite.color.a);
+        return state;
+    }
+
+    public override void ApplyState(RewindState state)
+    {
+        base.ApplyState(state);
+        hasDetected = state.GetCustomData<bool>("hasDetected");
+
+        Color c = sprite.color;
+        c.a = state.GetCustomData<float>("spriteAlpha");
+        sprite.color = c;
+    }
+}

--- a/Assets/Scripts/EnemyLogic/GhostEnemy.cs.meta
+++ b/Assets/Scripts/EnemyLogic/GhostEnemy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e82b44244b53e84e941b62a4868e0e3

--- a/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs
+++ b/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs
@@ -152,6 +152,15 @@ public class MeleeSkeleton : EnemyBase
     {
         var state = base.CaptureState();
         state.SetCustomData("isAttacking", isAttacking);
+        state.SetCustomData("spriteEnabled", spriteRenderer != null && spriteRenderer.enabled);
+
+        if (animator != null)
+        {
+            AnimatorStateInfo info = animator.GetCurrentAnimatorStateInfo(0);
+            state.AnimatorStateHash = info.shortNameHash;
+            state.AnimatorNormalizedTime = info.normalizedTime;
+        }
+
         return state;
     }
 
@@ -159,6 +168,12 @@ public class MeleeSkeleton : EnemyBase
     {
         base.ApplyState(state);
         isAttacking = state.GetCustomData<bool>("isAttacking");
+
+        if (spriteRenderer != null)
+            spriteRenderer.enabled = state.GetCustomData<bool>("spriteEnabled", true);
+
+        if (animator != null)
+            animator.Play(state.AnimatorStateHash, 0, state.AnimatorNormalizedTime);
     }
 
     void OnDrawGizmosSelected()

--- a/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs
+++ b/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs
@@ -1,0 +1,170 @@
+using UnityEngine;
+using System.Collections;
+using TimeRewind;
+
+public class MeleeSkeleton : EnemyBase
+{
+    [Header("Stats")]
+    public float detectionRange = 6f;
+    public float attackRange = 1.2f;
+    public float moveSpeed = 2.5f;
+    public float attackCooldown = 1.2f;
+    public int damage = 1;
+
+    [Header("Attack Hitbox")]
+    public float hitboxRadius = 0.6f;
+    public float hitboxOffset = 0.8f;
+
+    public Transform player;
+
+    private Animator animator;
+    private SpriteRenderer spriteRenderer;
+
+    private float lastAttackTime;
+    private bool isAttacking;
+
+    private enum State { Idle, Chase, Attack }
+    private State currentState = State.Idle;
+    private bool isHitStunned;
+
+    protected override void Awake()
+    {
+        health = 3;
+        knockbackResistance = 3f;
+        base.Awake();
+    }
+
+    void Start()
+    {
+        animator = GetComponentInChildren<Animator>();
+        spriteRenderer = GetComponentInChildren<SpriteRenderer>();
+        rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+    }
+
+    void Update()
+    {
+        if (isRewinding || wasDead) return;
+        if (isAttacking || isHitStunned) return;
+        if (player == null) return;
+
+        float dist = Vector2.Distance(transform.position, player.position);
+
+        if (dist <= attackRange && Time.time >= lastAttackTime + attackCooldown)
+            currentState = State.Attack;
+        else if (dist < detectionRange)
+            currentState = State.Chase;
+        else
+            currentState = State.Idle;
+
+        switch (currentState)
+        {
+            case State.Idle:
+                rb.linearVelocity = new Vector2(0, rb.linearVelocity.y);
+                animator.SetBool("isRunning", false);
+                break;
+
+            case State.Chase:
+                Vector2 dir = (player.position - transform.position).normalized;
+                rb.linearVelocity = new Vector2(dir.x * moveSpeed, rb.linearVelocity.y);
+                spriteRenderer.flipX = dir.x < 0;
+                animator.SetBool("isRunning", true);
+                break;
+
+            case State.Attack:
+                rb.linearVelocity = new Vector2(0, rb.linearVelocity.y);
+                animator.SetBool("isRunning", false);
+                StartCoroutine(AttackRoutine());
+                break;
+        }
+    }
+
+    IEnumerator AttackRoutine()
+    {
+        isAttacking = true;
+        lastAttackTime = Time.time;
+        animator.SetTrigger("Attack");
+        // Wait long enough for the animation to finish before allowing another attack
+        yield return new WaitForSeconds(attackCooldown * 0.9f);
+        isAttacking = false;
+    }
+
+    public override void TakeDamage(int amount)
+    {
+        if (wasDead) return;
+        animator.SetTrigger("Hit");
+        StartCoroutine(HitStunRoutine());
+        base.TakeDamage(amount);
+    }
+
+    IEnumerator HitStunRoutine()
+    {
+        isHitStunned = true;
+        yield return new WaitForSeconds(0.2f);
+        isHitStunned = false;
+    }
+
+    // Called by Animation Event on the attack clip at the swing frame
+    public void MeleeHit()
+    {
+        if (wasDead || isRewinding || player == null) return;
+
+        float dir = spriteRenderer.flipX ? -1f : 1f;
+        Vector2 hitPos = (Vector2)transform.position + new Vector2(dir * hitboxOffset, 0);
+
+        if (Vector2.Distance(hitPos, player.position) <= hitboxRadius)
+        {
+            player.GetComponent<PlayerHealth>()?.ModifyHealth(-damage);
+        }
+    }
+
+    public override void Die()
+    {
+        wasDead = true;
+        StopAllCoroutines();
+        isAttacking = false;
+
+        animator.SetTrigger("Die");
+        rb.linearVelocity = Vector2.zero;
+        rb.gravityScale = 0f;
+
+        Collider2D col = GetComponent<Collider2D>();
+        if (col != null) col.enabled = false;
+
+        StartCoroutine(base.DeathRoutine());
+    }
+
+    // ================= REWIND =================
+
+    public override void OnStartRewind()
+    {
+        base.OnStartRewind();
+        StopAllCoroutines();
+        isAttacking = false;
+    }
+
+    public override void OnStopRewind()
+    {
+        base.OnStopRewind();
+        isAttacking = false;
+    }
+
+    public override RewindState CaptureState()
+    {
+        var state = base.CaptureState();
+        state.SetCustomData("isAttacking", isAttacking);
+        return state;
+    }
+
+    public override void ApplyState(RewindState state)
+    {
+        base.ApplyState(state);
+        isAttacking = state.GetCustomData<bool>("isAttacking");
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        float dir = (spriteRenderer != null && spriteRenderer.flipX) ? -1f : 1f;
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere((Vector2)transform.position + new Vector2(dir * hitboxOffset, 0), hitboxRadius);
+    }
+}

--- a/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs.meta
+++ b/Assets/Scripts/EnemyLogic/MeleeSkeleton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 27ce4def3b3ed0a408851d92721b9cda

--- a/Assets/Sprites/Ghost.meta
+++ b/Assets/Sprites/Ghost.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aabdf269c9898e346a7ccab3d0c071bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/Effect-Sheet.png
+++ b/Assets/Sprites/Ghost/Effect-Sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:babdb94be3b99d3a4bf6154d5b960a7cd4089381240b456e252d365869610e21
+size 940

--- a/Assets/Sprites/Ghost/Effect-Sheet.png.meta
+++ b/Assets/Sprites/Ghost/Effect-Sheet.png.meta
@@ -1,0 +1,325 @@
+fileFormatVersion: 2
+guid: 0a1ddf30d48b79949b40797f1bd1586c
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: 6925525122209130197
+    second: Effect-Sheet_0
+  - first:
+      213: -5942306437869812341
+    second: Effect-Sheet_1
+  - first:
+      213: 7366780163746290201
+    second: Effect-Sheet_2
+  - first:
+      213: 5900379286273462060
+    second: Effect-Sheet_3
+  - first:
+      213: -4792111992401846795
+    second: Effect-Sheet_4
+  - first:
+      213: 6848925564159667144
+    second: Effect-Sheet_5
+  - first:
+      213: -7977999045849837200
+    second: Effect-Sheet_6
+  - first:
+      213: 2444281402331082648
+    second: Effect-Sheet_7
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Effect-Sheet_0
+      rect:
+        serializedVersion: 2
+        x: 15
+        y: 17
+        width: 20
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5d6a158d7686c1060800000000000000
+      internalID: 6925525122209130197
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_1
+      rect:
+        serializedVersion: 2
+        x: 61
+        y: 17
+        width: 22
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: b85c04847cfa88da0800000000000000
+      internalID: -5942306437869812341
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_2
+      rect:
+        serializedVersion: 2
+        x: 113
+        y: 17
+        width: 18
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 91add7e278f0c3660800000000000000
+      internalID: 7366780163746290201
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_3
+      rect:
+        serializedVersion: 2
+        x: 157
+        y: 17
+        width: 22
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c2f076603bb52e150800000000000000
+      internalID: 5900379286273462060
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_4
+      rect:
+        serializedVersion: 2
+        x: 214
+        y: 17
+        width: 13
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5fd9ff8588ffe7db0800000000000000
+      internalID: -4792111992401846795
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_5
+      rect:
+        serializedVersion: 2
+        x: 257
+        y: 15
+        width: 19
+        height: 19
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8cb24d073854c0f50800000000000000
+      internalID: 6848925564159667144
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_6
+      rect:
+        serializedVersion: 2
+        x: 302
+        y: 13
+        width: 23
+        height: 23
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 07117b51324784190800000000000000
+      internalID: -7977999045849837200
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Effect-Sheet_7
+      rect:
+        serializedVersion: 2
+        x: 350
+        y: 12
+        width: 24
+        height: 24
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 89fa90d2cf4dbe120800000000000000
+      internalID: 2444281402331082648
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      Effect-Sheet_0: 6925525122209130197
+      Effect-Sheet_1: -5942306437869812341
+      Effect-Sheet_2: 7366780163746290201
+      Effect-Sheet_3: 5900379286273462060
+      Effect-Sheet_4: -4792111992401846795
+      Effect-Sheet_5: 6848925564159667144
+      Effect-Sheet_6: -7977999045849837200
+      Effect-Sheet_7: 2444281402331082648
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/Ghost-Sheet.png
+++ b/Assets/Sprites/Ghost/Ghost-Sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42f2e89c47429893e1a1d04399fc66ac82be3f60e36b970297f130701c13ccac
+size 28846

--- a/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
+++ b/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
@@ -298,7 +298,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
+++ b/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
@@ -364,12 +364,12 @@ TextureImporter:
       name: Ghost-Sheet_0
       rect:
         serializedVersion: 2
-        x: 44
-        y: 739
-        width: 26
-        height: 40
+        x: 0
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -386,12 +386,12 @@ TextureImporter:
       name: Ghost-Sheet_1
       rect:
         serializedVersion: 2
-        x: 154
-        y: 739
-        width: 26
-        height: 40
+        x: 110
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -408,12 +408,12 @@ TextureImporter:
       name: Ghost-Sheet_2
       rect:
         serializedVersion: 2
-        x: 264
-        y: 739
-        width: 26
-        height: 39
+        x: 220
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -430,12 +430,12 @@ TextureImporter:
       name: Ghost-Sheet_3
       rect:
         serializedVersion: 2
-        x: 374
-        y: 737
-        width: 26
-        height: 40
+        x: 330
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -452,12 +452,12 @@ TextureImporter:
       name: Ghost-Sheet_4
       rect:
         serializedVersion: 2
-        x: 483
-        y: 737
-        width: 28
-        height: 40
+        x: 440
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -474,12 +474,12 @@ TextureImporter:
       name: Ghost-Sheet_5
       rect:
         serializedVersion: 2
-        x: 593
-        y: 737
-        width: 28
-        height: 40
+        x: 550
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -496,12 +496,12 @@ TextureImporter:
       name: Ghost-Sheet_6
       rect:
         serializedVersion: 2
-        x: 704
-        y: 738
-        width: 26
-        height: 40
+        x: 660
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -518,12 +518,12 @@ TextureImporter:
       name: Ghost-Sheet_7
       rect:
         serializedVersion: 2
-        x: 814
-        y: 739
-        width: 26
-        height: 40
+        x: 770
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -540,12 +540,12 @@ TextureImporter:
       name: Ghost-Sheet_8
       rect:
         serializedVersion: 2
-        x: 45
-        y: 659
-        width: 28
-        height: 40
+        x: 0
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -562,12 +562,12 @@ TextureImporter:
       name: Ghost-Sheet_9
       rect:
         serializedVersion: 2
-        x: 154
-        y: 659
-        width: 29
-        height: 39
+        x: 110
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -584,12 +584,12 @@ TextureImporter:
       name: Ghost-Sheet_10
       rect:
         serializedVersion: 2
-        x: 263
-        y: 659
-        width: 30
-        height: 38
+        x: 220
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -606,12 +606,12 @@ TextureImporter:
       name: Ghost-Sheet_11
       rect:
         serializedVersion: 2
-        x: 372
-        y: 659
-        width: 31
-        height: 38
+        x: 330
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -628,12 +628,12 @@ TextureImporter:
       name: Ghost-Sheet_12
       rect:
         serializedVersion: 2
-        x: 483
-        y: 660
-        width: 30
-        height: 38
+        x: 440
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -650,12 +650,12 @@ TextureImporter:
       name: Ghost-Sheet_13
       rect:
         serializedVersion: 2
-        x: 594
-        y: 660
-        width: 29
-        height: 39
+        x: 550
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -672,12 +672,12 @@ TextureImporter:
       name: Ghost-Sheet_14
       rect:
         serializedVersion: 2
-        x: 46
-        y: 579
-        width: 25
-        height: 40
+        x: 0
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -694,12 +694,12 @@ TextureImporter:
       name: Ghost-Sheet_15
       rect:
         serializedVersion: 2
-        x: 155
-        y: 579
-        width: 26
-        height: 39
+        x: 110
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -716,12 +716,12 @@ TextureImporter:
       name: Ghost-Sheet_16
       rect:
         serializedVersion: 2
-        x: 264
-        y: 579
-        width: 27
-        height: 38
+        x: 220
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -738,12 +738,12 @@ TextureImporter:
       name: Ghost-Sheet_17
       rect:
         serializedVersion: 2
-        x: 373
-        y: 579
-        width: 28
-        height: 38
+        x: 330
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -760,12 +760,12 @@ TextureImporter:
       name: Ghost-Sheet_18
       rect:
         serializedVersion: 2
-        x: 484
-        y: 580
-        width: 27
-        height: 38
+        x: 440
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -782,12 +782,12 @@ TextureImporter:
       name: Ghost-Sheet_19
       rect:
         serializedVersion: 2
-        x: 595
-        y: 580
-        width: 26
-        height: 39
+        x: 550
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -804,12 +804,12 @@ TextureImporter:
       name: Ghost-Sheet_20
       rect:
         serializedVersion: 2
-        x: 46
-        y: 500
-        width: 25
-        height: 36
+        x: 0
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -826,12 +826,12 @@ TextureImporter:
       name: Ghost-Sheet_21
       rect:
         serializedVersion: 2
-        x: 156
-        y: 500
-        width: 24
-        height: 36
+        x: 110
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -848,12 +848,12 @@ TextureImporter:
       name: Ghost-Sheet_22
       rect:
         serializedVersion: 2
-        x: 265
-        y: 501
-        width: 24
-        height: 38
+        x: 220
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -870,12 +870,12 @@ TextureImporter:
       name: Ghost-Sheet_23
       rect:
         serializedVersion: 2
-        x: 376
-        y: 500
-        width: 24
-        height: 39
+        x: 330
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -892,12 +892,12 @@ TextureImporter:
       name: Ghost-Sheet_24
       rect:
         serializedVersion: 2
-        x: 46
-        y: 420
-        width: 25
-        height: 36
+        x: 0
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -914,12 +914,12 @@ TextureImporter:
       name: Ghost-Sheet_25
       rect:
         serializedVersion: 2
-        x: 156
-        y: 420
-        width: 24
-        height: 36
+        x: 110
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -936,12 +936,12 @@ TextureImporter:
       name: Ghost-Sheet_26
       rect:
         serializedVersion: 2
-        x: 265
-        y: 421
-        width: 24
-        height: 38
+        x: 220
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -958,12 +958,12 @@ TextureImporter:
       name: Ghost-Sheet_27
       rect:
         serializedVersion: 2
-        x: 376
-        y: 420
-        width: 24
-        height: 39
+        x: 330
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -980,12 +980,12 @@ TextureImporter:
       name: Ghost-Sheet_28
       rect:
         serializedVersion: 2
-        x: 46
-        y: 340
-        width: 25
-        height: 36
+        x: 0
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1002,12 +1002,12 @@ TextureImporter:
       name: Ghost-Sheet_29
       rect:
         serializedVersion: 2
-        x: 156
-        y: 340
-        width: 24
-        height: 36
+        x: 110
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1024,12 +1024,12 @@ TextureImporter:
       name: Ghost-Sheet_30
       rect:
         serializedVersion: 2
-        x: 265
-        y: 341
-        width: 24
-        height: 38
+        x: 220
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1046,12 +1046,12 @@ TextureImporter:
       name: Ghost-Sheet_31
       rect:
         serializedVersion: 2
-        x: 379
-        y: 340
-        width: 19
-        height: 39
+        x: 330
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1068,12 +1068,12 @@ TextureImporter:
       name: Ghost-Sheet_32
       rect:
         serializedVersion: 2
-        x: 488
-        y: 340
-        width: 17
-        height: 40
+        x: 440
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1090,12 +1090,12 @@ TextureImporter:
       name: Ghost-Sheet_33
       rect:
         serializedVersion: 2
-        x: 599
-        y: 369
-        width: 6
-        height: 8
+        x: 550
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1112,12 +1112,12 @@ TextureImporter:
       name: Ghost-Sheet_34
       rect:
         serializedVersion: 2
-        x: 601
-        y: 259
-        width: 130
-        height: 125
+        x: 660
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1134,12 +1134,12 @@ TextureImporter:
       name: Ghost-Sheet_35
       rect:
         serializedVersion: 2
-        x: 375
-        y: 355
-        width: 7
-        height: 13
+        x: 0
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1156,12 +1156,12 @@ TextureImporter:
       name: Ghost-Sheet_36
       rect:
         serializedVersion: 2
-        x: 485
-        y: 353
-        width: 6
-        height: 13
+        x: 110
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1178,12 +1178,12 @@ TextureImporter:
       name: Ghost-Sheet_37
       rect:
         serializedVersion: 2
-        x: 503
-        y: 354
-        width: 6
-        height: 9
+        x: 220
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1200,12 +1200,12 @@ TextureImporter:
       name: Ghost-Sheet_38
       rect:
         serializedVersion: 2
-        x: 593
-        y: 354
-        width: 6
-        height: 13
+        x: 330
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1222,12 +1222,12 @@ TextureImporter:
       name: Ghost-Sheet_39
       rect:
         serializedVersion: 2
-        x: 605
-        y: 350
-        width: 8
-        height: 11
+        x: 440
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1244,12 +1244,12 @@ TextureImporter:
       name: Ghost-Sheet_40
       rect:
         serializedVersion: 2
-        x: 603
-        y: 340
-        width: 8
-        height: 13
+        x: 550
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1266,12 +1266,12 @@ TextureImporter:
       name: Ghost-Sheet_41
       rect:
         serializedVersion: 2
-        x: 46
-        y: 260
-        width: 25
-        height: 36
+        x: 660
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1288,12 +1288,12 @@ TextureImporter:
       name: Ghost-Sheet_42
       rect:
         serializedVersion: 2
-        x: 156
-        y: 260
-        width: 24
-        height: 36
+        x: 0
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1310,12 +1310,12 @@ TextureImporter:
       name: Ghost-Sheet_43
       rect:
         serializedVersion: 2
-        x: 265
-        y: 261
-        width: 24
-        height: 38
+        x: 110
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1332,12 +1332,12 @@ TextureImporter:
       name: Ghost-Sheet_44
       rect:
         serializedVersion: 2
-        x: 379
-        y: 260
-        width: 19
-        height: 39
+        x: 220
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1354,12 +1354,12 @@ TextureImporter:
       name: Ghost-Sheet_45
       rect:
         serializedVersion: 2
-        x: 488
-        y: 260
-        width: 17
-        height: 40
+        x: 330
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1376,12 +1376,12 @@ TextureImporter:
       name: Ghost-Sheet_46
       rect:
         serializedVersion: 2
-        x: 599
-        y: 289
-        width: 6
-        height: 8
+        x: 440
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1398,12 +1398,12 @@ TextureImporter:
       name: Ghost-Sheet_47
       rect:
         serializedVersion: 2
-        x: 601
-        y: 280
-        width: 11
-        height: 22
+        x: 550
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1420,12 +1420,12 @@ TextureImporter:
       name: Ghost-Sheet_48
       rect:
         serializedVersion: 2
-        x: 375
-        y: 275
-        width: 7
-        height: 13
+        x: 660
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1442,12 +1442,12 @@ TextureImporter:
       name: Ghost-Sheet_49
       rect:
         serializedVersion: 2
-        x: 485
-        y: 273
-        width: 6
-        height: 13
+        x: 770
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1464,12 +1464,12 @@ TextureImporter:
       name: Ghost-Sheet_50
       rect:
         serializedVersion: 2
-        x: 503
-        y: 274
-        width: 6
-        height: 9
+        x: 880
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1486,12 +1486,12 @@ TextureImporter:
       name: Ghost-Sheet_51
       rect:
         serializedVersion: 2
-        x: 593
-        y: 274
-        width: 6
-        height: 13
+        x: 990
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1508,12 +1508,12 @@ TextureImporter:
       name: Ghost-Sheet_52
       rect:
         serializedVersion: 2
-        x: 605
-        y: 270
-        width: 8
-        height: 11
+        x: 1100
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1530,12 +1530,12 @@ TextureImporter:
       name: Ghost-Sheet_53
       rect:
         serializedVersion: 2
-        x: 603
-        y: 260
-        width: 8
-        height: 13
+        x: 1210
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1552,12 +1552,12 @@ TextureImporter:
       name: Ghost-Sheet_54
       rect:
         serializedVersion: 2
-        x: 46
-        y: 180
-        width: 25
-        height: 36
+        x: 1320
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1574,12 +1574,12 @@ TextureImporter:
       name: Ghost-Sheet_55
       rect:
         serializedVersion: 2
-        x: 156
-        y: 180
-        width: 24
-        height: 36
+        x: 1430
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1596,12 +1596,12 @@ TextureImporter:
       name: Ghost-Sheet_56
       rect:
         serializedVersion: 2
-        x: 265
-        y: 181
-        width: 24
-        height: 38
+        x: 0
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1618,12 +1618,12 @@ TextureImporter:
       name: Ghost-Sheet_57
       rect:
         serializedVersion: 2
-        x: 376
-        y: 178
-        width: 24
-        height: 39
+        x: 110
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1640,12 +1640,12 @@ TextureImporter:
       name: Ghost-Sheet_58
       rect:
         serializedVersion: 2
-        x: 481
-        y: 173
-        width: 29
-        height: 38
+        x: 220
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1662,12 +1662,12 @@ TextureImporter:
       name: Ghost-Sheet_59
       rect:
         serializedVersion: 2
-        x: 593
-        y: 173
-        width: 28
-        height: 32
+        x: 330
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1684,12 +1684,12 @@ TextureImporter:
       name: Ghost-Sheet_60
       rect:
         serializedVersion: 2
-        x: 700
-        y: 173
-        width: 33
-        height: 12
+        x: 440
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1706,12 +1706,12 @@ TextureImporter:
       name: Ghost-Sheet_61
       rect:
         serializedVersion: 2
-        x: 704
-        y: 183
-        width: 6
-        height: 6
+        x: 550
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1728,12 +1728,12 @@ TextureImporter:
       name: Ghost-Sheet_62
       rect:
         serializedVersion: 2
-        x: 720
-        y: 183
-        width: 6
-        height: 6
+        x: 660
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1750,12 +1750,12 @@ TextureImporter:
       name: Ghost-Sheet_63
       rect:
         serializedVersion: 2
-        x: 814
-        y: 178
-        width: 6
-        height: 6
+        x: 770
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1772,12 +1772,12 @@ TextureImporter:
       name: Ghost-Sheet_64
       rect:
         serializedVersion: 2
-        x: 830
-        y: 178
-        width: 6
-        height: 6
+        x: 0
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1794,12 +1794,12 @@ TextureImporter:
       name: Ghost-Sheet_65
       rect:
         serializedVersion: 2
-        x: 808
-        y: 173
-        width: 38
-        height: 7
+        x: 110
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1816,12 +1816,12 @@ TextureImporter:
       name: Ghost-Sheet_66
       rect:
         serializedVersion: 2
-        x: 918
-        y: 173
-        width: 38
-        height: 8
+        x: 220
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1838,12 +1838,12 @@ TextureImporter:
       name: Ghost-Sheet_67
       rect:
         serializedVersion: 2
-        x: 1028
-        y: 173
-        width: 38
-        height: 6
+        x: 330
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1860,12 +1860,12 @@ TextureImporter:
       name: Ghost-Sheet_68
       rect:
         serializedVersion: 2
-        x: 1138
-        y: 173
-        width: 38
-        height: 6
+        x: 440
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1882,12 +1882,12 @@ TextureImporter:
       name: Ghost-Sheet_69
       rect:
         serializedVersion: 2
-        x: 1248
-        y: 173
-        width: 26
-        height: 6
+        x: 550
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1904,12 +1904,12 @@ TextureImporter:
       name: Ghost-Sheet_70
       rect:
         serializedVersion: 2
-        x: 1270
-        y: 173
-        width: 236
-        height: 6
+        x: 660
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1926,12 +1926,12 @@ TextureImporter:
       name: Ghost-Sheet_71
       rect:
         serializedVersion: 2
-        x: 45
-        y: 99
-        width: 26
-        height: 40
+        x: 770
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1948,12 +1948,12 @@ TextureImporter:
       name: Ghost-Sheet_72
       rect:
         serializedVersion: 2
-        x: 155
-        y: 100
-        width: 28
-        height: 39
+        x: 880
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -1966,341 +1966,11 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_73
-      rect:
-        serializedVersion: 2
-        x: 265
-        y: 99
-        width: 25
-        height: 43
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 72093858616f9fd10800000000000000
-      internalID: 2160028072890568743
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_74
-      rect:
-        serializedVersion: 2
-        x: 370
-        y: 100
-        width: 42
-        height: 42
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 51df1a75723fc8d50800000000000000
-      internalID: 6741030092566297877
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_75
-      rect:
-        serializedVersion: 2
-        x: 481
-        y: 100
-        width: 40
-        height: 35
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 5b39b5c6d72f8c850800000000000000
-      internalID: 6397629891182564277
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_76
-      rect:
-        serializedVersion: 2
-        x: 595
-        y: 98
-        width: 28
-        height: 40
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 7a170f5a48cc209a0800000000000000
-      internalID: -6268222861254561369
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_77
-      rect:
-        serializedVersion: 2
-        x: 706
-        y: 99
-        width: 25
-        height: 40
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 4dbed3fadb96e8ca0800000000000000
-      internalID: -6012752189083227180
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_78
-      rect:
-        serializedVersion: 2
-        x: 815
-        y: 99
-        width: 26
-        height: 40
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 1da099b2e8204f0e0800000000000000
-      internalID: -2237160305256232239
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_79
-      rect:
-        serializedVersion: 2
-        x: 46
-        y: 20
-        width: 24
-        height: 39
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: e4d9f10ea04693180800000000000000
-      internalID: -9135160371271721650
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_80
-      rect:
-        serializedVersion: 2
-        x: 155
-        y: 21
-        width: 24
-        height: 38
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 5f3a06fdeeda85220800000000000000
-      internalID: 2474919236701561845
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_81
-      rect:
-        serializedVersion: 2
-        x: 261
-        y: 20
-        width: 31
-        height: 35
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 65b711779db87cec0800000000000000
-      internalID: -3546712415409177770
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_82
-      rect:
-        serializedVersion: 2
-        x: 370
-        y: 20
-        width: 32
-        height: 35
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 72fd26bd3320fe7c0800000000000000
-      internalID: -4040007918980767961
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_83
-      rect:
-        serializedVersion: 2
-        x: 480
-        y: 20
-        width: 32
-        height: 34
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 4f0eb08ae1387a9b0800000000000000
-      internalID: -5068938687890595596
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_84
-      rect:
-        serializedVersion: 2
-        x: 591
-        y: 20
-        width: 31
-        height: 34
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 65eae481b7ce0f2b0800000000000000
-      internalID: -5552678327114879402
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_85
-      rect:
-        serializedVersion: 2
-        x: 701
-        y: 20
-        width: 31
-        height: 35
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 6321c077c30c62350800000000000000
-      internalID: 5991687720190874166
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_86
-      rect:
-        serializedVersion: 2
-        x: 815
-        y: 18
-        width: 26
-        height: 41
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: e539fbb48c7249cd0800000000000000
-      internalID: -2552371347594439842
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Ghost-Sheet_87
-      rect:
-        serializedVersion: 2
-        x: 925
-        y: 19
-        width: 26
-        height: 40
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 4cc904be837988400800000000000000
-      internalID: 326677243705203908
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 8129632395a8b134b8a238015b3b6dd3
     internalID: 0
     vertices: []
     indices: 
@@ -2308,7 +1978,9 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":14.0,"y":10.0},"gridSpriteSize":{"x":110.0,"y":80.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Ghost-Sheet_0: -5662871578180991815
       Ghost-Sheet_1: 7189840374964406950
@@ -2381,22 +2053,7 @@ TextureImporter:
       Ghost-Sheet_70: 1369101704673193724
       Ghost-Sheet_71: -2188763869845313403
       Ghost-Sheet_72: 2601953975672582542
-      Ghost-Sheet_73: 2160028072890568743
-      Ghost-Sheet_74: 6741030092566297877
-      Ghost-Sheet_75: 6397629891182564277
-      Ghost-Sheet_76: -6268222861254561369
-      Ghost-Sheet_77: -6012752189083227180
-      Ghost-Sheet_78: -2237160305256232239
-      Ghost-Sheet_79: -9135160371271721650
       Ghost-Sheet_8: -1891757779967955749
-      Ghost-Sheet_80: 2474919236701561845
-      Ghost-Sheet_81: -3546712415409177770
-      Ghost-Sheet_82: -4040007918980767961
-      Ghost-Sheet_83: -5068938687890595596
-      Ghost-Sheet_84: -5552678327114879402
-      Ghost-Sheet_85: 5991687720190874166
-      Ghost-Sheet_86: -2552371347594439842
-      Ghost-Sheet_87: 326677243705203908
       Ghost-Sheet_9: -6005555052213164162
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0

--- a/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
+++ b/Assets/Sprites/Ghost/Ghost-Sheet.png.meta
@@ -1,0 +1,2405 @@
+fileFormatVersion: 2
+guid: 6842cbad4fdbb2f419f5e34c99861ef1
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -5662871578180991815
+    second: Ghost-Sheet_0
+  - first:
+      213: 7189840374964406950
+    second: Ghost-Sheet_1
+  - first:
+      213: -3718347094540284078
+    second: Ghost-Sheet_2
+  - first:
+      213: -7578058256828440795
+    second: Ghost-Sheet_3
+  - first:
+      213: -7284506132182457801
+    second: Ghost-Sheet_4
+  - first:
+      213: 7588984183233628690
+    second: Ghost-Sheet_5
+  - first:
+      213: -8248075664900341140
+    second: Ghost-Sheet_6
+  - first:
+      213: 8160510040787513936
+    second: Ghost-Sheet_7
+  - first:
+      213: -1891757779967955749
+    second: Ghost-Sheet_8
+  - first:
+      213: -6005555052213164162
+    second: Ghost-Sheet_9
+  - first:
+      213: -2049783107406774795
+    second: Ghost-Sheet_10
+  - first:
+      213: -5888340099575219574
+    second: Ghost-Sheet_11
+  - first:
+      213: 6435068506290440632
+    second: Ghost-Sheet_12
+  - first:
+      213: 7586682290592745534
+    second: Ghost-Sheet_13
+  - first:
+      213: 6772229276325582705
+    second: Ghost-Sheet_14
+  - first:
+      213: -7248826445337618832
+    second: Ghost-Sheet_15
+  - first:
+      213: 3320851844911287227
+    second: Ghost-Sheet_16
+  - first:
+      213: 6485472295691103955
+    second: Ghost-Sheet_17
+  - first:
+      213: -3133204106564292067
+    second: Ghost-Sheet_18
+  - first:
+      213: 1482023486056457262
+    second: Ghost-Sheet_19
+  - first:
+      213: -8811548906721358493
+    second: Ghost-Sheet_20
+  - first:
+      213: 5516157233673174888
+    second: Ghost-Sheet_21
+  - first:
+      213: 3352898723551327629
+    second: Ghost-Sheet_22
+  - first:
+      213: 3928586849903868211
+    second: Ghost-Sheet_23
+  - first:
+      213: 227186290669854190
+    second: Ghost-Sheet_24
+  - first:
+      213: -3455557111089544384
+    second: Ghost-Sheet_25
+  - first:
+      213: -146523137162065135
+    second: Ghost-Sheet_26
+  - first:
+      213: 4174768993444101763
+    second: Ghost-Sheet_27
+  - first:
+      213: -3369901217048674818
+    second: Ghost-Sheet_28
+  - first:
+      213: 1499731486029602087
+    second: Ghost-Sheet_29
+  - first:
+      213: -2487790232211330787
+    second: Ghost-Sheet_30
+  - first:
+      213: -6882123139462236256
+    second: Ghost-Sheet_31
+  - first:
+      213: -7046186555868634914
+    second: Ghost-Sheet_32
+  - first:
+      213: -2334981703340389872
+    second: Ghost-Sheet_33
+  - first:
+      213: -4724208596424722546
+    second: Ghost-Sheet_34
+  - first:
+      213: -8950961764941701792
+    second: Ghost-Sheet_35
+  - first:
+      213: 939017510130731671
+    second: Ghost-Sheet_36
+  - first:
+      213: -7399933452470866305
+    second: Ghost-Sheet_37
+  - first:
+      213: 8113703731383039281
+    second: Ghost-Sheet_38
+  - first:
+      213: -1484733580086299299
+    second: Ghost-Sheet_39
+  - first:
+      213: 1545198708021872079
+    second: Ghost-Sheet_40
+  - first:
+      213: -1556136872762731801
+    second: Ghost-Sheet_41
+  - first:
+      213: -8769961997384865353
+    second: Ghost-Sheet_42
+  - first:
+      213: 729921436667244478
+    second: Ghost-Sheet_43
+  - first:
+      213: 6332535380473115282
+    second: Ghost-Sheet_44
+  - first:
+      213: -4200276741221723315
+    second: Ghost-Sheet_45
+  - first:
+      213: 5495833030937723106
+    second: Ghost-Sheet_46
+  - first:
+      213: -4391166799911596604
+    second: Ghost-Sheet_47
+  - first:
+      213: -1594039897936622988
+    second: Ghost-Sheet_48
+  - first:
+      213: 6597295025754922807
+    second: Ghost-Sheet_49
+  - first:
+      213: 6191602160960914956
+    second: Ghost-Sheet_50
+  - first:
+      213: 6676556187387783355
+    second: Ghost-Sheet_51
+  - first:
+      213: -673922364520972676
+    second: Ghost-Sheet_52
+  - first:
+      213: 149340185047355614
+    second: Ghost-Sheet_53
+  - first:
+      213: 1339949381197507569
+    second: Ghost-Sheet_54
+  - first:
+      213: -1859525295578826284
+    second: Ghost-Sheet_55
+  - first:
+      213: -4036769736779595478
+    second: Ghost-Sheet_56
+  - first:
+      213: -6542090729457049008
+    second: Ghost-Sheet_57
+  - first:
+      213: 7511078059107051260
+    second: Ghost-Sheet_58
+  - first:
+      213: 567078956418803713
+    second: Ghost-Sheet_59
+  - first:
+      213: -4658325734196776613
+    second: Ghost-Sheet_60
+  - first:
+      213: 9111988206487763765
+    second: Ghost-Sheet_61
+  - first:
+      213: 6191878236109176912
+    second: Ghost-Sheet_62
+  - first:
+      213: 6116232461617233164
+    second: Ghost-Sheet_63
+  - first:
+      213: -8765266739606036066
+    second: Ghost-Sheet_64
+  - first:
+      213: -3006398401863656812
+    second: Ghost-Sheet_65
+  - first:
+      213: 8861459350882583364
+    second: Ghost-Sheet_66
+  - first:
+      213: 3045638129416729036
+    second: Ghost-Sheet_67
+  - first:
+      213: -3469974003213676685
+    second: Ghost-Sheet_68
+  - first:
+      213: 948139582335987666
+    second: Ghost-Sheet_69
+  - first:
+      213: 1369101704673193724
+    second: Ghost-Sheet_70
+  - first:
+      213: -2188763869845313403
+    second: Ghost-Sheet_71
+  - first:
+      213: 2601953975672582542
+    second: Ghost-Sheet_72
+  - first:
+      213: 2160028072890568743
+    second: Ghost-Sheet_73
+  - first:
+      213: 6741030092566297877
+    second: Ghost-Sheet_74
+  - first:
+      213: 6397629891182564277
+    second: Ghost-Sheet_75
+  - first:
+      213: -6268222861254561369
+    second: Ghost-Sheet_76
+  - first:
+      213: -6012752189083227180
+    second: Ghost-Sheet_77
+  - first:
+      213: -2237160305256232239
+    second: Ghost-Sheet_78
+  - first:
+      213: -9135160371271721650
+    second: Ghost-Sheet_79
+  - first:
+      213: 2474919236701561845
+    second: Ghost-Sheet_80
+  - first:
+      213: -3546712415409177770
+    second: Ghost-Sheet_81
+  - first:
+      213: -4040007918980767961
+    second: Ghost-Sheet_82
+  - first:
+      213: -5068938687890595596
+    second: Ghost-Sheet_83
+  - first:
+      213: -5552678327114879402
+    second: Ghost-Sheet_84
+  - first:
+      213: 5991687720190874166
+    second: Ghost-Sheet_85
+  - first:
+      213: -2552371347594439842
+    second: Ghost-Sheet_86
+  - first:
+      213: 326677243705203908
+    second: Ghost-Sheet_87
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Ghost-Sheet_0
+      rect:
+        serializedVersion: 2
+        x: 44
+        y: 739
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 9b4cdd58d407961b0800000000000000
+      internalID: -5662871578180991815
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_1
+      rect:
+        serializedVersion: 2
+        x: 154
+        y: 739
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 6aac3854ab177c360800000000000000
+      internalID: 7189840374964406950
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_2
+      rect:
+        serializedVersion: 2
+        x: 264
+        y: 739
+        width: 26
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 25f0256a407c56cc0800000000000000
+      internalID: -3718347094540284078
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_3
+      rect:
+        serializedVersion: 2
+        x: 374
+        y: 737
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 52f568a6a2455d690800000000000000
+      internalID: -7578058256828440795
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_4
+      rect:
+        serializedVersion: 2
+        x: 483
+        y: 737
+        width: 28
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7322c1b844c38ea90800000000000000
+      internalID: -7284506132182457801
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_5
+      rect:
+        serializedVersion: 2
+        x: 593
+        y: 737
+        width: 28
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 21ac2bf08ec715960800000000000000
+      internalID: 7588984183233628690
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_6
+      rect:
+        serializedVersion: 2
+        x: 704
+        y: 738
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c62421902e2f88d80800000000000000
+      internalID: -8248075664900341140
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_7
+      rect:
+        serializedVersion: 2
+        x: 814
+        y: 739
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 052f52755a4ff3170800000000000000
+      internalID: 8160510040787513936
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_8
+      rect:
+        serializedVersion: 2
+        x: 45
+        y: 659
+        width: 28
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: bdcade372502fb5e0800000000000000
+      internalID: -1891757779967955749
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_9
+      rect:
+        serializedVersion: 2
+        x: 154
+        y: 659
+        width: 29
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e7728c1bf7bf7aca0800000000000000
+      internalID: -6005555052213164162
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_10
+      rect:
+        serializedVersion: 2
+        x: 263
+        y: 659
+        width: 30
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5fd3c60cf15bd83e0800000000000000
+      internalID: -2049783107406774795
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_11
+      rect:
+        serializedVersion: 2
+        x: 372
+        y: 659
+        width: 31
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a8a712090e9684ea0800000000000000
+      internalID: -5888340099575219574
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_12
+      rect:
+        serializedVersion: 2
+        x: 483
+        y: 660
+        width: 30
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8b9ceb646b4fd4950800000000000000
+      internalID: 6435068506290440632
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_13
+      rect:
+        serializedVersion: 2
+        x: 594
+        y: 660
+        width: 29
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e38078ae85f494960800000000000000
+      internalID: 7586682290592745534
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_14
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 579
+        width: 25
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 17713e065aacbfd50800000000000000
+      internalID: 6772229276325582705
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_15
+      rect:
+        serializedVersion: 2
+        x: 155
+        y: 579
+        width: 26
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 076913ff0cef66b90800000000000000
+      internalID: -7248826445337618832
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_16
+      rect:
+        serializedVersion: 2
+        x: 264
+        y: 579
+        width: 27
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: bbb43a78829061e20800000000000000
+      internalID: 3320851844911287227
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_17
+      rect:
+        serializedVersion: 2
+        x: 373
+        y: 579
+        width: 28
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 3de2e4101b6010a50800000000000000
+      internalID: 6485472295691103955
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_18
+      rect:
+        serializedVersion: 2
+        x: 484
+        y: 580
+        width: 27
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d12b07b277f9484d0800000000000000
+      internalID: -3133204106564292067
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_19
+      rect:
+        serializedVersion: 2
+        x: 595
+        y: 580
+        width: 26
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e246e2b2284319410800000000000000
+      internalID: 1482023486056457262
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_20
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 500
+        width: 25
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 36d44e574f617b580800000000000000
+      internalID: -8811548906721358493
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_21
+      rect:
+        serializedVersion: 2
+        x: 156
+        y: 500
+        width: 24
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 86f7a4637c35d8c40800000000000000
+      internalID: 5516157233673174888
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_22
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 501
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d853329ef93e78e20800000000000000
+      internalID: 3352898723551327629
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_23
+      rect:
+        serializedVersion: 2
+        x: 376
+        y: 500
+        width: 24
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 3397ac9ece4258630800000000000000
+      internalID: 3928586849903868211
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_24
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 420
+        width: 25
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: eed17394ab0272300800000000000000
+      internalID: 227186290669854190
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_25
+      rect:
+        serializedVersion: 2
+        x: 156
+        y: 420
+        width: 24
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 043ce64ad156b00d0800000000000000
+      internalID: -3455557111089544384
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_26
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 421
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 11b441aabf177fdf0800000000000000
+      internalID: -146523137162065135
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_27
+      rect:
+        serializedVersion: 2
+        x: 376
+        y: 420
+        width: 24
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 38efc89d742cfe930800000000000000
+      internalID: 4174768993444101763
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_28
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 340
+        width: 25
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: efd38a592b4bb31d0800000000000000
+      internalID: -3369901217048674818
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_29
+      rect:
+        serializedVersion: 2
+        x: 156
+        y: 340
+        width: 24
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 72d534337dd10d410800000000000000
+      internalID: 1499731486029602087
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_30
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 341
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d196b55f6f7997dd0800000000000000
+      internalID: -2487790232211330787
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_31
+      rect:
+        serializedVersion: 2
+        x: 379
+        y: 340
+        width: 19
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 0a77bdbb779cd70a0800000000000000
+      internalID: -6882123139462236256
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_32
+      rect:
+        serializedVersion: 2
+        x: 488
+        y: 340
+        width: 17
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ed02154e8aae63e90800000000000000
+      internalID: -7046186555868634914
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_33
+      rect:
+        serializedVersion: 2
+        x: 599
+        y: 369
+        width: 6
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 01a0c57138a789fd0800000000000000
+      internalID: -2334981703340389872
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_34
+      rect:
+        serializedVersion: 2
+        x: 601
+        y: 259
+        width: 130
+        height: 125
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e87f14dbf4d307eb0800000000000000
+      internalID: -4724208596424722546
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_35
+      rect:
+        serializedVersion: 2
+        x: 375
+        y: 355
+        width: 7
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 06ddb82f2bbc7c380800000000000000
+      internalID: -8950961764941701792
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_36
+      rect:
+        serializedVersion: 2
+        x: 485
+        y: 353
+        width: 6
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 79ac639437f080d00800000000000000
+      internalID: 939017510130731671
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_37
+      rect:
+        serializedVersion: 2
+        x: 503
+        y: 354
+        width: 6
+        height: 9
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f7ea1f34bb72e4990800000000000000
+      internalID: -7399933452470866305
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_38
+      rect:
+        serializedVersion: 2
+        x: 593
+        y: 354
+        width: 6
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 135f8d13e8aa99070800000000000000
+      internalID: 8113703731383039281
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_39
+      rect:
+        serializedVersion: 2
+        x: 605
+        y: 350
+        width: 8
+        height: 11
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d55bcd4ecaa256be0800000000000000
+      internalID: -1484733580086299299
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_40
+      rect:
+        serializedVersion: 2
+        x: 603
+        y: 340
+        width: 8
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: fc54903c906a17510800000000000000
+      internalID: 1545198708021872079
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_41
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 260
+        width: 25
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7e2171d42cd776ae0800000000000000
+      internalID: -1556136872762731801
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_42
+      rect:
+        serializedVersion: 2
+        x: 156
+        y: 260
+        width: 24
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7b923345706da4680800000000000000
+      internalID: -8769961997384865353
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_43
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 261
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ebf6e7aeda3312a00800000000000000
+      internalID: 729921436667244478
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_44
+      rect:
+        serializedVersion: 2
+        x: 379
+        y: 260
+        width: 19
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 29271b8906fa1e750800000000000000
+      internalID: 6332535380473115282
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_45
+      rect:
+        serializedVersion: 2
+        x: 488
+        y: 260
+        width: 17
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d43d421de8e95b5c0800000000000000
+      internalID: -4200276741221723315
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_46
+      rect:
+        serializedVersion: 2
+        x: 599
+        y: 289
+        width: 6
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 2e0c6e1060f154c40800000000000000
+      internalID: 5495833030937723106
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_47
+      rect:
+        serializedVersion: 2
+        x: 601
+        y: 280
+        width: 11
+        height: 22
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4cdc7c59f017f03c0800000000000000
+      internalID: -4391166799911596604
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_48
+      rect:
+        serializedVersion: 2
+        x: 375
+        y: 275
+        width: 7
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 47a00bd8825d0e9e0800000000000000
+      internalID: -1594039897936622988
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_49
+      rect:
+        serializedVersion: 2
+        x: 485
+        y: 273
+        width: 6
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 73fd2983fdc4e8b50800000000000000
+      internalID: 6597295025754922807
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_50
+      rect:
+        serializedVersion: 2
+        x: 503
+        y: 274
+        width: 6
+        height: 9
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c06cd926c5dfce550800000000000000
+      internalID: 6191602160960914956
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_51
+      rect:
+        serializedVersion: 2
+        x: 593
+        y: 274
+        width: 6
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: bb86f208a74e7ac50800000000000000
+      internalID: 6676556187387783355
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_52
+      rect:
+        serializedVersion: 2
+        x: 605
+        y: 270
+        width: 8
+        height: 11
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c7e39881e2fb5a6f0800000000000000
+      internalID: -673922364520972676
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_53
+      rect:
+        serializedVersion: 2
+        x: 603
+        y: 260
+        width: 8
+        height: 13
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ed050786b10921200800000000000000
+      internalID: 149340185047355614
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_54
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 180
+        width: 25
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 1fb2843ecd4789210800000000000000
+      internalID: 1339949381197507569
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_55
+      rect:
+        serializedVersion: 2
+        x: 156
+        y: 180
+        width: 24
+        height: 36
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4d9bb2a8893a136e0800000000000000
+      internalID: -1859525295578826284
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_56
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 181
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a218437ef438af7c0800000000000000
+      internalID: -4036769736779595478
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_57
+      rect:
+        serializedVersion: 2
+        x: 376
+        y: 178
+        width: 24
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 052265e9423d535a0800000000000000
+      internalID: -6542090729457049008
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_58
+      rect:
+        serializedVersion: 2
+        x: 481
+        y: 173
+        width: 29
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: cf66e4903b5bc3860800000000000000
+      internalID: 7511078059107051260
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_59
+      rect:
+        serializedVersion: 2
+        x: 593
+        y: 173
+        width: 28
+        height: 32
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 10821fc6e4baed700800000000000000
+      internalID: 567078956418803713
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_60
+      rect:
+        serializedVersion: 2
+        x: 700
+        y: 173
+        width: 33
+        height: 12
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: b51f325fc6d4a5fb0800000000000000
+      internalID: -4658325734196776613
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_61
+      rect:
+        serializedVersion: 2
+        x: 704
+        y: 183
+        width: 6
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 53b70451ff8447e70800000000000000
+      internalID: 9111988206487763765
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_62
+      rect:
+        serializedVersion: 2
+        x: 720
+        y: 183
+        width: 6
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 05082c32378fde550800000000000000
+      internalID: 6191878236109176912
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_63
+      rect:
+        serializedVersion: 2
+        x: 814
+        y: 178
+        width: 6
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c0d7866c40931e450800000000000000
+      internalID: 6116232461617233164
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_64
+      rect:
+        serializedVersion: 2
+        x: 830
+        y: 178
+        width: 6
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e916c3837548b5680800000000000000
+      internalID: -8765266739606036066
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_65
+      rect:
+        serializedVersion: 2
+        x: 808
+        y: 173
+        width: 38
+        height: 7
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 49a5d9305902746d0800000000000000
+      internalID: -3006398401863656812
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_66
+      rect:
+        serializedVersion: 2
+        x: 918
+        y: 173
+        width: 38
+        height: 8
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4438be0645a3afa70800000000000000
+      internalID: 8861459350882583364
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_67
+      rect:
+        serializedVersion: 2
+        x: 1028
+        y: 173
+        width: 38
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: cc1f4420eb7444a20800000000000000
+      internalID: 3045638129416729036
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_68
+      rect:
+        serializedVersion: 2
+        x: 1138
+        y: 173
+        width: 38
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 37fcb9e570d28dfc0800000000000000
+      internalID: -3469974003213676685
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_69
+      rect:
+        serializedVersion: 2
+        x: 1248
+        y: 173
+        width: 26
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 2dfaf9a3de7782d00800000000000000
+      internalID: 948139582335987666
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_70
+      rect:
+        serializedVersion: 2
+        x: 1270
+        y: 173
+        width: 236
+        height: 6
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: cfe6d602fb6000310800000000000000
+      internalID: 1369101704673193724
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_71
+      rect:
+        serializedVersion: 2
+        x: 45
+        y: 99
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 58829a06bd2ff91e0800000000000000
+      internalID: -2188763869845313403
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_72
+      rect:
+        serializedVersion: 2
+        x: 155
+        y: 100
+        width: 28
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e8131e9ea5ffb1420800000000000000
+      internalID: 2601953975672582542
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_73
+      rect:
+        serializedVersion: 2
+        x: 265
+        y: 99
+        width: 25
+        height: 43
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 72093858616f9fd10800000000000000
+      internalID: 2160028072890568743
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_74
+      rect:
+        serializedVersion: 2
+        x: 370
+        y: 100
+        width: 42
+        height: 42
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 51df1a75723fc8d50800000000000000
+      internalID: 6741030092566297877
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_75
+      rect:
+        serializedVersion: 2
+        x: 481
+        y: 100
+        width: 40
+        height: 35
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5b39b5c6d72f8c850800000000000000
+      internalID: 6397629891182564277
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_76
+      rect:
+        serializedVersion: 2
+        x: 595
+        y: 98
+        width: 28
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7a170f5a48cc209a0800000000000000
+      internalID: -6268222861254561369
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_77
+      rect:
+        serializedVersion: 2
+        x: 706
+        y: 99
+        width: 25
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4dbed3fadb96e8ca0800000000000000
+      internalID: -6012752189083227180
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_78
+      rect:
+        serializedVersion: 2
+        x: 815
+        y: 99
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 1da099b2e8204f0e0800000000000000
+      internalID: -2237160305256232239
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_79
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 20
+        width: 24
+        height: 39
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e4d9f10ea04693180800000000000000
+      internalID: -9135160371271721650
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_80
+      rect:
+        serializedVersion: 2
+        x: 155
+        y: 21
+        width: 24
+        height: 38
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5f3a06fdeeda85220800000000000000
+      internalID: 2474919236701561845
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_81
+      rect:
+        serializedVersion: 2
+        x: 261
+        y: 20
+        width: 31
+        height: 35
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 65b711779db87cec0800000000000000
+      internalID: -3546712415409177770
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_82
+      rect:
+        serializedVersion: 2
+        x: 370
+        y: 20
+        width: 32
+        height: 35
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 72fd26bd3320fe7c0800000000000000
+      internalID: -4040007918980767961
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_83
+      rect:
+        serializedVersion: 2
+        x: 480
+        y: 20
+        width: 32
+        height: 34
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4f0eb08ae1387a9b0800000000000000
+      internalID: -5068938687890595596
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_84
+      rect:
+        serializedVersion: 2
+        x: 591
+        y: 20
+        width: 31
+        height: 34
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 65eae481b7ce0f2b0800000000000000
+      internalID: -5552678327114879402
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_85
+      rect:
+        serializedVersion: 2
+        x: 701
+        y: 20
+        width: 31
+        height: 35
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 6321c077c30c62350800000000000000
+      internalID: 5991687720190874166
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_86
+      rect:
+        serializedVersion: 2
+        x: 815
+        y: 18
+        width: 26
+        height: 41
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e539fbb48c7249cd0800000000000000
+      internalID: -2552371347594439842
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Ghost-Sheet_87
+      rect:
+        serializedVersion: 2
+        x: 925
+        y: 19
+        width: 26
+        height: 40
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 4cc904be837988400800000000000000
+      internalID: 326677243705203908
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      Ghost-Sheet_0: -5662871578180991815
+      Ghost-Sheet_1: 7189840374964406950
+      Ghost-Sheet_10: -2049783107406774795
+      Ghost-Sheet_11: -5888340099575219574
+      Ghost-Sheet_12: 6435068506290440632
+      Ghost-Sheet_13: 7586682290592745534
+      Ghost-Sheet_14: 6772229276325582705
+      Ghost-Sheet_15: -7248826445337618832
+      Ghost-Sheet_16: 3320851844911287227
+      Ghost-Sheet_17: 6485472295691103955
+      Ghost-Sheet_18: -3133204106564292067
+      Ghost-Sheet_19: 1482023486056457262
+      Ghost-Sheet_2: -3718347094540284078
+      Ghost-Sheet_20: -8811548906721358493
+      Ghost-Sheet_21: 5516157233673174888
+      Ghost-Sheet_22: 3352898723551327629
+      Ghost-Sheet_23: 3928586849903868211
+      Ghost-Sheet_24: 227186290669854190
+      Ghost-Sheet_25: -3455557111089544384
+      Ghost-Sheet_26: -146523137162065135
+      Ghost-Sheet_27: 4174768993444101763
+      Ghost-Sheet_28: -3369901217048674818
+      Ghost-Sheet_29: 1499731486029602087
+      Ghost-Sheet_3: -7578058256828440795
+      Ghost-Sheet_30: -2487790232211330787
+      Ghost-Sheet_31: -6882123139462236256
+      Ghost-Sheet_32: -7046186555868634914
+      Ghost-Sheet_33: -2334981703340389872
+      Ghost-Sheet_34: -4724208596424722546
+      Ghost-Sheet_35: -8950961764941701792
+      Ghost-Sheet_36: 939017510130731671
+      Ghost-Sheet_37: -7399933452470866305
+      Ghost-Sheet_38: 8113703731383039281
+      Ghost-Sheet_39: -1484733580086299299
+      Ghost-Sheet_4: -7284506132182457801
+      Ghost-Sheet_40: 1545198708021872079
+      Ghost-Sheet_41: -1556136872762731801
+      Ghost-Sheet_42: -8769961997384865353
+      Ghost-Sheet_43: 729921436667244478
+      Ghost-Sheet_44: 6332535380473115282
+      Ghost-Sheet_45: -4200276741221723315
+      Ghost-Sheet_46: 5495833030937723106
+      Ghost-Sheet_47: -4391166799911596604
+      Ghost-Sheet_48: -1594039897936622988
+      Ghost-Sheet_49: 6597295025754922807
+      Ghost-Sheet_5: 7588984183233628690
+      Ghost-Sheet_50: 6191602160960914956
+      Ghost-Sheet_51: 6676556187387783355
+      Ghost-Sheet_52: -673922364520972676
+      Ghost-Sheet_53: 149340185047355614
+      Ghost-Sheet_54: 1339949381197507569
+      Ghost-Sheet_55: -1859525295578826284
+      Ghost-Sheet_56: -4036769736779595478
+      Ghost-Sheet_57: -6542090729457049008
+      Ghost-Sheet_58: 7511078059107051260
+      Ghost-Sheet_59: 567078956418803713
+      Ghost-Sheet_6: -8248075664900341140
+      Ghost-Sheet_60: -4658325734196776613
+      Ghost-Sheet_61: 9111988206487763765
+      Ghost-Sheet_62: 6191878236109176912
+      Ghost-Sheet_63: 6116232461617233164
+      Ghost-Sheet_64: -8765266739606036066
+      Ghost-Sheet_65: -3006398401863656812
+      Ghost-Sheet_66: 8861459350882583364
+      Ghost-Sheet_67: 3045638129416729036
+      Ghost-Sheet_68: -3469974003213676685
+      Ghost-Sheet_69: 948139582335987666
+      Ghost-Sheet_7: 8160510040787513936
+      Ghost-Sheet_70: 1369101704673193724
+      Ghost-Sheet_71: -2188763869845313403
+      Ghost-Sheet_72: 2601953975672582542
+      Ghost-Sheet_73: 2160028072890568743
+      Ghost-Sheet_74: 6741030092566297877
+      Ghost-Sheet_75: 6397629891182564277
+      Ghost-Sheet_76: -6268222861254561369
+      Ghost-Sheet_77: -6012752189083227180
+      Ghost-Sheet_78: -2237160305256232239
+      Ghost-Sheet_79: -9135160371271721650
+      Ghost-Sheet_8: -1891757779967955749
+      Ghost-Sheet_80: 2474919236701561845
+      Ghost-Sheet_81: -3546712415409177770
+      Ghost-Sheet_82: -4040007918980767961
+      Ghost-Sheet_83: -5068938687890595596
+      Ghost-Sheet_84: -5552678327114879402
+      Ghost-Sheet_85: 5991687720190874166
+      Ghost-Sheet_86: -2552371347594439842
+      Ghost-Sheet_87: 326677243705203908
+      Ghost-Sheet_9: -6005555052213164162
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostAnimator.controller
+++ b/Assets/Sprites/Ghost/GhostAnimator.controller
@@ -1,0 +1,388 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-7898948006397136918
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostHit
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3250189380365287995}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 3a33a463f2bd9ef418483fc6d283c8da, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-7453729536851381965
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isChasing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-5104059991357729993
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostIdle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5539761655130419759}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 3c4b175280fa97546b3275818953181b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-4553736599263981147
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -5104059991357729993}
+    m_Position: {x: 310, y: 240, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1934197330474370561}
+    m_Position: {x: 330, y: -30, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4430932657642249593}
+    m_Position: {x: 600, y: 180, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7898948006397136918}
+    m_Position: {x: 500, y: 90, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 260959344335884000}
+    m_Position: {x: 338.3333, y: 356.33334, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: 6832320143801520245}
+  - {fileID: 5096675991720759018}
+  - {fileID: 5020529851637361304}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 0, y: 190, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -5104059991357729993}
+--- !u!1101 &-3250189380365287995
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-1934197330474370561
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostAttack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2355798563739200813}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f1cc3738e4f86eb4cbc0f35982cb435c, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostAnimator
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: isChasing
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Hit
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Die
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -4553736599263981147}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &260959344335884000
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostMove
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -7453729536851381965}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 148cb51ad59cb9f4aa0937f7f526719c, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &2355798563739200813
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &4430932657642249593
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostDeath
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 89523d0c4d0533f46abdf61371740622, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5020529851637361304
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Die
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4430932657642249593}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5096675991720759018
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Hit
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7898948006397136918}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5539761655130419759
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isChasing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 260959344335884000}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.625
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &6832320143801520245
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1934197330474370561}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Assets/Sprites/Ghost/GhostAnimator.controller
+++ b/Assets/Sprites/Ghost/GhostAnimator.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-9045457333385571190
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: PhaseOut
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -517820593223688862}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
 --- !u!1102 &-7898948006397136918
 AnimatorState:
   serializedVersion: 6
@@ -27,31 +52,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-7453729536851381965
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 2
-    m_ConditionEvent: isChasing
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -5104059991357729993}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &-5104059991357729993
 AnimatorState:
   serializedVersion: 6
@@ -63,7 +63,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 5539761655130419759}
+  - {fileID: -2657307633309039847}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -90,24 +90,32 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -5104059991357729993}
-    m_Position: {x: 310, y: 240, z: 0}
+    m_Position: {x: 280, y: 210, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1934197330474370561}
-    m_Position: {x: 330, y: -30, z: 0}
+    m_Position: {x: 470, y: -20, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4430932657642249593}
     m_Position: {x: 600, y: 180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7898948006397136918}
-    m_Position: {x: 500, y: 90, z: 0}
+    m_Position: {x: 480, y: 80, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: 260959344335884000}
-    m_Position: {x: 338.3333, y: 356.33334, z: 0}
+    m_State: {fileID: 4057953307225767365}
+    m_Position: {x: 330, y: -60, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -517820593223688862}
+    m_Position: {x: 190, y: -150, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3321803534474430820}
+    m_Position: {x: 468.66663, y: 357.92648, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 6832320143801520245}
   - {fileID: 5096675991720759018}
   - {fileID: 5020529851637361304}
+  - {fileID: -9045457333385571190}
+  - {fileID: 1987568115040491429}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -116,6 +124,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -5104059991357729993}
+--- !u!1101 &-3963049206945868218
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isChasing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-3250189380365287995
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -134,6 +167,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 1
   m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-2657307633309039847
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isChasing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3321803534474430820}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.625
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -165,6 +223,77 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-1082578241945240319
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-517820593223688862
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostPhaseOut
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -1082578241945240319}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 2210a5038226a054bb117d72b0691bbb, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-164242229410792859
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5104059991357729993}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -198,6 +327,18 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: PhaseOut
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: PhaseIn
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -211,33 +352,31 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
---- !u!1102 &260959344335884000
-AnimatorState:
-  serializedVersion: 6
+--- !u!1101 &1987568115040491429
+AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: GhostMove
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -7453729536851381965}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 148cb51ad59cb9f4aa0937f7f526719c, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: PhaseIn
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4057953307225767365}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
 --- !u!1101 &2355798563739200813
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -260,6 +399,60 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &3321803534474430820
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostChase
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3963049206945868218}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b86abd43d04e392488a695b2a53d9c37, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &4057953307225767365
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostPhaseIn
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -164242229410792859}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 3792be1eed9f3ef42a067c7e9324b5ad, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &4430932657642249593
 AnimatorState:
   serializedVersion: 6
@@ -303,14 +496,14 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
+  m_CanTransitionToSelf: 0
 --- !u!1101 &5096675991720759018
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -328,39 +521,14 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &5539761655130419759
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: isChasing
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 260959344335884000}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.625
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
+  m_CanTransitionToSelf: 0
 --- !u!1101 &6832320143801520245
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -378,11 +546,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
+  m_CanTransitionToSelf: 0

--- a/Assets/Sprites/Ghost/GhostAnimator.controller.meta
+++ b/Assets/Sprites/Ghost/GhostAnimator.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc4cd9170ee6bc0479c82252de781bfc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostAttack.anim
+++ b/Assets/Sprites/Ghost/GhostAttack.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostAttack
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostAttack.anim
+++ b/Assets/Sprites/Ghost/GhostAttack.anim
@@ -17,21 +17,61 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -4036769736779595478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: -6542090729457049008, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: 7511078059107051260, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: 567078956418803713, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: -4658325734196776613, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: 9111988206487763765, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5
+      value: {fileID: 6191878236109176912, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5833333
+      value: {fileID: 6116232461617233164, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -4036769736779595478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -6542090729457049008, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 7511078059107051260, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 567078956418803713, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4658325734196776613, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 9111988206487763765, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6191878236109176912, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6116232461617233164, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.6666666
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -50,4 +90,18 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.25
+    functionName: 
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.25
+    functionName: GhostDealDamage
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Sprites/Ghost/GhostAttack.anim.meta
+++ b/Assets/Sprites/Ghost/GhostAttack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1cc3738e4f86eb4cbc0f35982cb435c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostChase.anim
+++ b/Assets/Sprites/Ghost/GhostChase.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostChase
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostChase.anim
+++ b/Assets/Sprites/Ghost/GhostChase.anim
@@ -17,21 +17,55 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -1891757779967955749, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: -6005555052213164162, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: -2049783107406774795, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: -5888340099575219574, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: 6435068506290440632, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: 7586682290592745534, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -1891757779967955749, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -6005555052213164162, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -2049783107406774795, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -5888340099575219574, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6435068506290440632, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 7586682290592745534, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.5
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Sprites/Ghost/GhostChase.anim.meta
+++ b/Assets/Sprites/Ghost/GhostChase.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b86abd43d04e392488a695b2a53d9c37
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostDeath.anim
+++ b/Assets/Sprites/Ghost/GhostDeath.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostDeath
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostDeath.anim
+++ b/Assets/Sprites/Ghost/GhostDeath.anim
@@ -17,26 +17,63 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -3369901217048674818, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: 1499731486029602087, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: -2487790232211330787, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: -6882123139462236256, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: -7046186555868634914, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: -2334981703340389872, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5
+      value: {fileID: -4724208596424722546, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -3369901217048674818, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 1499731486029602087, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -2487790232211330787, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -6882123139462236256, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -7046186555868634914, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -2334981703340389872, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4724208596424722546, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.5833333
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Sprites/Ghost/GhostDeath.anim.meta
+++ b/Assets/Sprites/Ghost/GhostDeath.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89523d0c4d0533f46abdf61371740622
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostHit.anim
+++ b/Assets/Sprites/Ghost/GhostHit.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostHit
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostHit.anim
+++ b/Assets/Sprites/Ghost/GhostHit.anim
@@ -17,21 +17,49 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -8811548906721358493, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: 5516157233673174888, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: 3352898723551327629, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: 3928586849903868211, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -8811548906721358493, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 5516157233673174888, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 3352898723551327629, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 3928586849903868211, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.33333334
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Sprites/Ghost/GhostHit.anim.meta
+++ b/Assets/Sprites/Ghost/GhostHit.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a33a463f2bd9ef418483fc6d283c8da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostIdle.anim
+++ b/Assets/Sprites/Ghost/GhostIdle.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostIdle
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostIdle.anim
+++ b/Assets/Sprites/Ghost/GhostIdle.anim
@@ -17,21 +17,61 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -5662871578180991815, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: 7189840374964406950, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: -3718347094540284078, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: -7578058256828440795, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: -7284506132182457801, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: 7588984183233628690, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5
+      value: {fileID: -8248075664900341140, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5833333
+      value: {fileID: 8160510040787513936, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -5662871578180991815, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 7189840374964406950, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -3718347094540284078, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -7578058256828440795, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -7284506132182457801, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 7588984183233628690, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -8248075664900341140, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 8160510040787513936, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.6666666
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Sprites/Ghost/GhostIdle.anim.meta
+++ b/Assets/Sprites/Ghost/GhostIdle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c4b175280fa97546b3275818953181b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/GhostPhaseIn.anim
+++ b/Assets/Sprites/Ghost/GhostPhaseIn.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GhostPhaseIn
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/GhostPhaseIn.anim
+++ b/Assets/Sprites/Ghost/GhostPhaseIn.anim
@@ -17,26 +17,84 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -1859525295578826284, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: 1339949381197507569, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: 149340185047355614, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: -673922364520972676, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: 6676556187387783355, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: 6191602160960914956, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5
+      value: {fileID: 6597295025754922807, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5833333
+      value: {fileID: -1594039897936622988, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.6666667
+      value: {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.75
+      value: {fileID: 5495833030937723106, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.8333333
+      value: {fileID: -4200276741221723315, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.9166667
+      value: {fileID: 6332535380473115282, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 1
+      value: {fileID: 729921436667244478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 1.0833334
+      value: {fileID: -8769961997384865353, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -1859525295578826284, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 1339949381197507569, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 149340185047355614, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -673922364520972676, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6676556187387783355, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6191602160960914956, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6597295025754922807, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -1594039897936622988, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 5495833030937723106, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4200276741221723315, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6332535380473115282, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 729921436667244478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -8769961997384865353, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 1.1666667
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Sprites/Ghost/GhostPhaseIn.anim.meta
+++ b/Assets/Sprites/Ghost/GhostPhaseIn.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3792be1eed9f3ef42a067c7e9324b5ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Ghost/Ghostphaseout.anim
+++ b/Assets/Sprites/Ghost/Ghostphaseout.anim
@@ -17,26 +17,81 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -8769961997384865353, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.083333336
+      value: {fileID: 729921436667244478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.16666667
+      value: {fileID: 6332535380473115282, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.25
+      value: {fileID: 5495833030937723106, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.33333334
+      value: {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.41666666
+      value: {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5
+      value: {fileID: -1594039897936622988, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.5833333
+      value: {fileID: 6597295025754922807, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.6666667
+      value: {fileID: 6191602160960914956, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.75
+      value: {fileID: 6676556187387783355, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.8333333
+      value: {fileID: -673922364520972676, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 0.9166667
+      value: {fileID: 149340185047355614, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - time: 1
+      value: {fileID: -1859525295578826284, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -8769961997384865353, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 729921436667244478, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6332535380473115282, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 5495833030937723106, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -4391166799911596604, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -1594039897936622988, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6597295025754922807, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6191602160960914956, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 6676556187387783355, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -673922364520972676, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: 149340185047355614, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
+    - {fileID: -1859525295578826284, guid: 6842cbad4fdbb2f419f5e34c99861ef1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 1.0833334
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Sprites/Ghost/Ghostphaseout.anim
+++ b/Assets/Sprites/Ghost/Ghostphaseout.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Ghostphaseout
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/Ghost/Ghostphaseout.anim.meta
+++ b/Assets/Sprites/Ghost/Ghostphaseout.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2210a5038226a054bb117d72b0691bbb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonArcher/Skeleton_Archer-Sheet.png.meta
+++ b/Assets/Sprites/SkeletonArcher/Skeleton_Archer-Sheet.png.meta
@@ -259,7 +259,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -325,10 +325,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_0
       rect:
         serializedVersion: 2
-        x: 43
-        y: 896
-        width: 32
-        height: 43
+        x: 0
+        y: 880
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -347,10 +347,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_1
       rect:
         serializedVersion: 2
-        x: 153
-        y: 896
-        width: 32
-        height: 42
+        x: 110
+        y: 880
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -369,10 +369,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_2
       rect:
         serializedVersion: 2
-        x: 263
-        y: 896
-        width: 32
-        height: 41
+        x: 220
+        y: 880
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -391,10 +391,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_3
       rect:
         serializedVersion: 2
-        x: 373
-        y: 896
-        width: 32
-        height: 42
+        x: 330
+        y: 880
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -413,10 +413,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_4
       rect:
         serializedVersion: 2
-        x: 47
-        y: 816
-        width: 36
-        height: 42
+        x: 0
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -435,10 +435,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_5
       rect:
         serializedVersion: 2
-        x: 156
-        y: 816
-        width: 36
-        height: 41
+        x: 110
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -457,10 +457,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_6
       rect:
         serializedVersion: 2
-        x: 263
-        y: 816
-        width: 38
-        height: 41
+        x: 220
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -479,10 +479,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_7
       rect:
         serializedVersion: 2
-        x: 373
-        y: 816
-        width: 39
-        height: 42
+        x: 330
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -501,10 +501,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_8
       rect:
         serializedVersion: 2
-        x: 483
-        y: 816
-        width: 38
-        height: 42
+        x: 440
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -523,10 +523,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_9
       rect:
         serializedVersion: 2
-        x: 593
-        y: 816
-        width: 39
-        height: 41
+        x: 550
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -545,10 +545,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_10
       rect:
         serializedVersion: 2
-        x: 703
-        y: 816
-        width: 38
-        height: 41
+        x: 660
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -567,10 +567,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_11
       rect:
         serializedVersion: 2
-        x: 816
-        y: 816
-        width: 36
-        height: 42
+        x: 770
+        y: 800
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -589,10 +589,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_12
       rect:
         serializedVersion: 2
-        x: 41
-        y: 736
-        width: 42
-        height: 41
+        x: 0
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -611,10 +611,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_13
       rect:
         serializedVersion: 2
-        x: 152
-        y: 736
-        width: 40
-        height: 40
+        x: 110
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -633,10 +633,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_14
       rect:
         serializedVersion: 2
-        x: 263
-        y: 736
-        width: 38
-        height: 40
+        x: 220
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -655,10 +655,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_15
       rect:
         serializedVersion: 2
-        x: 373
-        y: 736
-        width: 39
-        height: 41
+        x: 330
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -677,10 +677,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_16
       rect:
         serializedVersion: 2
-        x: 481
-        y: 736
-        width: 40
-        height: 41
+        x: 440
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -699,10 +699,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_17
       rect:
         serializedVersion: 2
-        x: 592
-        y: 736
-        width: 40
-        height: 40
+        x: 550
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -721,10 +721,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_18
       rect:
         serializedVersion: 2
-        x: 703
-        y: 736
-        width: 38
-        height: 40
+        x: 660
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -743,10 +743,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_19
       rect:
         serializedVersion: 2
-        x: 815
-        y: 736
-        width: 37
-        height: 41
+        x: 770
+        y: 720
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -765,10 +765,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_20
       rect:
         serializedVersion: 2
-        x: 44
-        y: 656
-        width: 35
-        height: 40
+        x: 0
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -787,10 +787,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_21
       rect:
         serializedVersion: 2
-        x: 154
-        y: 656
-        width: 35
-        height: 41
+        x: 110
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -809,10 +809,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_22
       rect:
         serializedVersion: 2
-        x: 258
-        y: 656
-        width: 31
-        height: 49
+        x: 220
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -831,10 +831,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_23
       rect:
         serializedVersion: 2
-        x: 371
-        y: 656
-        width: 29
-        height: 47
+        x: 330
+        y: 640
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -853,10 +853,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_24
       rect:
         serializedVersion: 2
-        x: 44
-        y: 576
-        width: 35
-        height: 40
+        x: 0
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -875,10 +875,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_25
       rect:
         serializedVersion: 2
-        x: 154
-        y: 576
-        width: 35
-        height: 41
+        x: 110
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -897,10 +897,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_26
       rect:
         serializedVersion: 2
-        x: 258
-        y: 576
-        width: 31
-        height: 49
+        x: 220
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -919,10 +919,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_27
       rect:
         serializedVersion: 2
-        x: 371
-        y: 576
-        width: 29
-        height: 47
+        x: 330
+        y: 560
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -941,10 +941,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_28
       rect:
         serializedVersion: 2
-        x: 44
-        y: 496
-        width: 35
-        height: 40
+        x: 0
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -963,10 +963,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_29
       rect:
         serializedVersion: 2
-        x: 154
-        y: 496
-        width: 35
-        height: 41
+        x: 110
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -985,10 +985,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_30
       rect:
         serializedVersion: 2
-        x: 258
-        y: 496
-        width: 31
-        height: 49
+        x: 220
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1007,10 +1007,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_31
       rect:
         serializedVersion: 2
-        x: 370
-        y: 496
-        width: 41
-        height: 43
+        x: 330
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1029,10 +1029,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_32
       rect:
         serializedVersion: 2
-        x: 475
-        y: 526
-        width: 8
-        height: 6
+        x: 440
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1051,10 +1051,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_33
       rect:
         serializedVersion: 2
-        x: 478
-        y: 496
-        width: 49
-        height: 24
+        x: 550
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1073,10 +1073,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_34
       rect:
         serializedVersion: 2
-        x: 583
-        y: 509
-        width: 6
-        height: 7
+        x: 660
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1095,10 +1095,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_35
       rect:
         serializedVersion: 2
-        x: 587
-        y: 496
-        width: 51
-        height: 15
+        x: 770
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1117,10 +1117,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_36
       rect:
         serializedVersion: 2
-        x: 691
-        y: 496
-        width: 58
-        height: 10
+        x: 880
+        y: 480
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1139,10 +1139,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_37
       rect:
         serializedVersion: 2
-        x: 802
-        y: 496
-        width: 57
-        height: 6
+        x: 0
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1161,10 +1161,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_38
       rect:
         serializedVersion: 2
-        x: 914
-        y: 496
-        width: 55
-        height: 6
+        x: 110
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1183,10 +1183,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_39
       rect:
         serializedVersion: 2
-        x: 44
-        y: 416
-        width: 35
-        height: 40
+        x: 220
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1205,10 +1205,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_40
       rect:
         serializedVersion: 2
-        x: 154
-        y: 416
-        width: 35
-        height: 41
+        x: 330
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1227,10 +1227,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_41
       rect:
         serializedVersion: 2
-        x: 258
-        y: 416
-        width: 31
-        height: 49
+        x: 440
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1249,10 +1249,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_42
       rect:
         serializedVersion: 2
-        x: 370
-        y: 416
-        width: 41
-        height: 43
+        x: 550
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1271,10 +1271,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_43
       rect:
         serializedVersion: 2
-        x: 475
-        y: 446
-        width: 8
-        height: 6
+        x: 660
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1293,10 +1293,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_44
       rect:
         serializedVersion: 2
-        x: 478
-        y: 416
-        width: 49
-        height: 24
+        x: 770
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1315,10 +1315,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_45
       rect:
         serializedVersion: 2
-        x: 583
-        y: 429
-        width: 6
-        height: 7
+        x: 880
+        y: 400
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1337,10 +1337,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_46
       rect:
         serializedVersion: 2
-        x: 587
-        y: 416
-        width: 51
-        height: 15
+        x: 0
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1359,10 +1359,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_47
       rect:
         serializedVersion: 2
-        x: 691
-        y: 416
-        width: 58
-        height: 10
+        x: 110
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1381,10 +1381,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_48
       rect:
         serializedVersion: 2
-        x: 802
-        y: 416
-        width: 57
-        height: 6
+        x: 220
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1403,10 +1403,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_49
       rect:
         serializedVersion: 2
-        x: 914
-        y: 416
-        width: 55
-        height: 6
+        x: 330
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1425,10 +1425,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_50
       rect:
         serializedVersion: 2
-        x: 475
-        y: 366
-        width: 8
-        height: 6
+        x: 440
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1447,10 +1447,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_51
       rect:
         serializedVersion: 2
-        x: 590
-        y: 336
-        width: 41
-        height: 43
+        x: 550
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1469,10 +1469,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_52
       rect:
         serializedVersion: 2
-        x: 698
-        y: 336
-        width: 31
-        height: 49
+        x: 660
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1491,10 +1491,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_53
       rect:
         serializedVersion: 2
-        x: 814
-        y: 336
-        width: 35
-        height: 41
+        x: 770
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1513,10 +1513,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_54
       rect:
         serializedVersion: 2
-        x: 924
-        y: 336
-        width: 35
-        height: 40
+        x: 880
+        y: 320
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1535,10 +1535,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_55
       rect:
         serializedVersion: 2
-        x: 363
-        y: 349
-        width: 6
-        height: 7
+        x: 0
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1557,10 +1557,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_56
       rect:
         serializedVersion: 2
-        x: 367
-        y: 336
-        width: 51
-        height: 15
+        x: 110
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1579,10 +1579,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_57
       rect:
         serializedVersion: 2
-        x: 478
-        y: 336
-        width: 49
-        height: 24
+        x: 220
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1601,10 +1601,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_58
       rect:
         serializedVersion: 2
-        x: 34
-        y: 336
-        width: 55
-        height: 6
+        x: 330
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1623,10 +1623,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_59
       rect:
         serializedVersion: 2
-        x: 142
-        y: 336
-        width: 57
-        height: 6
+        x: 440
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1645,10 +1645,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_60
       rect:
         serializedVersion: 2
-        x: 251
-        y: 336
-        width: 58
-        height: 10
+        x: 550
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1667,10 +1667,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_61
       rect:
         serializedVersion: 2
-        x: 43
-        y: 256
-        width: 32
-        height: 43
+        x: 660
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1689,10 +1689,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_62
       rect:
         serializedVersion: 2
-        x: 146
-        y: 256
-        width: 37
-        height: 52
+        x: 770
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1711,10 +1711,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_63
       rect:
         serializedVersion: 2
-        x: 262
-        y: 256
-        width: 30
-        height: 53
+        x: 880
+        y: 240
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1733,10 +1733,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_64
       rect:
         serializedVersion: 2
-        x: 372
-        y: 256
-        width: 43
-        height: 47
+        x: 0
+        y: 160
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1755,10 +1755,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_65
       rect:
         serializedVersion: 2
-        x: 481
-        y: 256
-        width: 41
-        height: 47
+        x: 0
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1777,10 +1777,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_66
       rect:
         serializedVersion: 2
-        x: 591
-        y: 256
-        width: 36
-        height: 47
+        x: 110
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1799,10 +1799,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_67
       rect:
         serializedVersion: 2
-        x: 701
-        y: 256
-        width: 33
-        height: 47
+        x: 220
+        y: 80
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1821,10 +1821,10 @@ TextureImporter:
       name: Skeleton_Archer-Sheet_68
       rect:
         serializedVersion: 2
-        x: 812
-        y: 256
-        width: 30
-        height: 47
+        x: 0
+        y: 0
+        width: 110
+        height: 80
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1835,138 +1835,6 @@ TextureImporter:
       bones: []
       spriteID: b2337a6a3a588d350800000000000000
       internalID: 6041725838039659307
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_69
-      rect:
-        serializedVersion: 2
-        x: 922
-        y: 256
-        width: 30
-        height: 48
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: acda9b320ca8f4650800000000000000
-      internalID: 6219342168259669450
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_70
-      rect:
-        serializedVersion: 2
-        x: 43
-        y: 176
-        width: 39
-        height: 41
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 575f9a15f4fcd3090800000000000000
-      internalID: -8053052619089119883
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_71
-      rect:
-        serializedVersion: 2
-        x: 43
-        y: 98
-        width: 39
-        height: 39
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 73ecdde2f7b0bf460800000000000000
-      internalID: 7276422263822208567
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_72
-      rect:
-        serializedVersion: 2
-        x: 154
-        y: 100
-        width: 36
-        height: 37
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 7195b7ce23c908d50800000000000000
-      internalID: 6737556785076066583
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_73
-      rect:
-        serializedVersion: 2
-        x: 261
-        y: 98
-        width: 28
-        height: 44
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: 5fe79058026f73d40800000000000000
-      internalID: 5564186484170915573
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Skeleton_Archer-Sheet_74
-      rect:
-        serializedVersion: 2
-        x: 41
-        y: 16
-        width: 28
-        height: 46
-      alignment: 0
-      pivot: {x: 0.5, y: 0.5}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      customData: 
-      outline: []
-      physicsShape: []
-      tessellationDetail: -1
-      bones: []
-      spriteID: b9e053df876ec84b0800000000000000
-      internalID: -5436717242824454501
       vertices: []
       indices: 
       edges: []
@@ -1985,7 +1853,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":9.0,"y":12.0},"gridSpriteSize":{"x":110.0,"y":80.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Skeleton_Archer-Sheet_0: 5392066793042786390
       Skeleton_Archer-Sheet_1: -1154594342682901094
@@ -2053,13 +1921,7 @@ TextureImporter:
       Skeleton_Archer-Sheet_66: 478048680693693820
       Skeleton_Archer-Sheet_67: 6444450461611899571
       Skeleton_Archer-Sheet_68: 6041725838039659307
-      Skeleton_Archer-Sheet_69: 6219342168259669450
       Skeleton_Archer-Sheet_7: 3271829635525413198
-      Skeleton_Archer-Sheet_70: -8053052619089119883
-      Skeleton_Archer-Sheet_71: 7276422263822208567
-      Skeleton_Archer-Sheet_72: 6737556785076066583
-      Skeleton_Archer-Sheet_73: 5564186484170915573
-      Skeleton_Archer-Sheet_74: -5436717242824454501
       Skeleton_Archer-Sheet_8: 9111949546175300900
       Skeleton_Archer-Sheet_9: 6992459241031140173
   mipmapLimitGroupName: 

--- a/Assets/Sprites/SkeletonWarrior.meta
+++ b/Assets/Sprites/SkeletonWarrior.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c8bb4ec86c251a479a5ee020df366f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller
@@ -1,5 +1,103 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-9177333837350340981
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Die
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4210377669413847503}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
+--- !u!1101 &-5722831160862793619
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 389850431262099483}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-5037300684058223471
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isRunning
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1691471951231591862}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.25
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-4210377669413847503
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorDeath
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: a303018a22d4c2d43b76be306687974b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1107 &-2934617391355784173
 AnimatorStateMachine:
   serializedVersion: 6
@@ -8,17 +106,136 @@ AnimatorStateMachine:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Base Layer
-  m_ChildStates: []
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -2875464316946207706}
+    m_Position: {x: 720, y: 120, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -4210377669413847503}
+    m_Position: {x: 744.99994, y: 248.33334, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 5215585194431127872}
+    m_Position: {x: 564.99994, y: -47.666687, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 389850431262099483}
+    m_Position: {x: 230, y: 180, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1691471951231591862}
+    m_Position: {x: 500, y: 320, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: 4128572057829957778}
+  - {fileID: 1984898766301233327}
+  - {fileID: -9177333837350340981}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_EntryPosition: {x: -70, y: 120, z: 0}
+  m_ExitPosition: {x: 1110, y: 130, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 0}
+  m_DefaultState: {fileID: 389850431262099483}
+--- !u!1102 &-2875464316946207706
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorAttack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -5722831160862793619}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: a0ee76fb6793ba0438b82d950d39fa71, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-2284432928088405513
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isRunning
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 389850431262099483}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.625
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-2032433692318071906
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 389850431262099483}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-1691471951231591862
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorMove
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -2284432928088405513}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: de329b32c71932a4ba9a2441bff64d65, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -27,7 +244,31 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: SkeletonWarriorAnimator
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: isRunning
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Die
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Hit
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -41,3 +282,107 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1102 &389850431262099483
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorIdle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -5037300684058223471}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 6fe8bce160aa57e4eba85bfab82a9ceb, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &1984898766301233327
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Hit
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5215585194431127872}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
+--- !u!1101 &4128572057829957778
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2875464316946207706}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
+--- !u!1102 &5215585194431127872
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorHit
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -2032433692318071906}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 1663419e825b17a489bb38d95435c7d7, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-2934617391355784173
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates: []
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 0}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorAnimator
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -2934617391355784173}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAnimator.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0222d30a0182ba4e84733b277413808
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim
@@ -17,15 +17,52 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -7655924358597185806, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.14285715
+      value: {fileID: -2783888251784152255, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.2857143
+      value: {fileID: 3245266416423409047, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.42857143
+      value: {fileID: 6309118879192772842, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.5714286
+      value: {fileID: 5856689563986140808, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.71428573
+      value: {fileID: -1832642307490167646, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.85714287
+      value: {fileID: 114462698314575130, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 7
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -7655924358597185806, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -2783888251784152255, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 3245266416423409047, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 6309118879192772842, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 5856689563986140808, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -1832642307490167646, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 114462698314575130, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
@@ -36,7 +73,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -50,4 +87,25 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.41666666
+    functionName: 
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.42857143
+    functionName: MeleeHit
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.71428573
+    functionName: 
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorAttack
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorAttack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0ee76fb6793ba0438b82d950d39fa71
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorDeath
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim
@@ -17,26 +17,69 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -7980866787232787362, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.083333336
+      value: {fileID: 6746486871487542874, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.16666667
+      value: {fileID: -7566304522830529697, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.25
+      value: {fileID: -3007108533385323757, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.33333334
+      value: {fileID: 5042002423084735932, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.41666666
+      value: {fileID: 8744336510436887853, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.5
+      value: {fileID: -6164231861814612728, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.5833333
+      value: {fileID: 8321978523517417068, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.6666667
+      value: {fileID: -2047976441770955684, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -7980866787232787362, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 6746486871487542874, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -7566304522830529697, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -3007108533385323757, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 5042002423084735932, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 8744336510436887853, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -6164231861814612728, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 8321978523517417068, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -2047976441770955684, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.75
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorDeath.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a303018a22d4c2d43b76be306687974b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorHit
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim
@@ -17,26 +17,54 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 6941000946644355005, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.083333336
+      value: {fileID: 2229347828428457895, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.16666667
+      value: {fileID: -6504620962370601389, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.25
+      value: {fileID: 7140751693236283513, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 6941000946644355005, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 2229347828428457895, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -6504620962370601389, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 7140751693236283513, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.33333334
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorHit.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1663419e825b17a489bb38d95435c7d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim
@@ -17,21 +17,49 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -3828820476789506080, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.083333336
+      value: {fileID: -3407714099261928723, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.16666667
+      value: {fileID: 9110729424731996572, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.25
+      value: {fileID: -5997758139635115862, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -3828820476789506080, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -3407714099261928723, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 9110729424731996572, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -5997758139635115862, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.33333334
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorIdle
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorIdle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fe8bce160aa57e4eba85bfab82a9ceb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim
@@ -17,21 +17,61 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
-  m_SampleRate: 60
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 4584584497781072885, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.083333336
+      value: {fileID: 5351624043617095465, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.16666667
+      value: {fileID: 5638019637627365415, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.25
+      value: {fileID: -5100863917353453704, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.33333334
+      value: {fileID: -6069009701636567001, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.41666666
+      value: {fileID: -7172212386086780211, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.5
+      value: {fileID: 2321704070081464267, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - time: 0.5833333
+      value: {fileID: 7372487006611317280, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 4584584497781072885, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 5351624043617095465, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 5638019637627365415, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -5100863917353453704, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -6069009701636567001, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: -7172212386086780211, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 2321704070081464267, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
+    - {fileID: 7372487006611317280, guid: e1b8d62ced372ce4cb6059b18ed28e35, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.6666666
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkeletonWarriorMove
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim.meta
+++ b/Assets/Sprites/SkeletonWarrior/SkeletonWarriorMove.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de329b32c71932a4ba9a2441bff64d65
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png
+++ b/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04ff2c4a603cd11b57d8c7be4092a1c9c6d144f4eb444e0e71b62eecfceb2447
+size 45245

--- a/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png.meta
+++ b/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png.meta
@@ -337,7 +337,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png.meta
+++ b/Assets/Sprites/SkeletonWarrior/Skeleton_Warrior-Sheet.png.meta
@@ -1,0 +1,2193 @@
+fileFormatVersion: 2
+guid: e1b8d62ced372ce4cb6059b18ed28e35
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -3828820476789506080
+    second: Skeleton_Warrior-Sheet_0
+  - first:
+      213: -3407714099261928723
+    second: Skeleton_Warrior-Sheet_1
+  - first:
+      213: 9110729424731996572
+    second: Skeleton_Warrior-Sheet_2
+  - first:
+      213: -5997758139635115862
+    second: Skeleton_Warrior-Sheet_3
+  - first:
+      213: 4584584497781072885
+    second: Skeleton_Warrior-Sheet_4
+  - first:
+      213: 5351624043617095465
+    second: Skeleton_Warrior-Sheet_5
+  - first:
+      213: 5638019637627365415
+    second: Skeleton_Warrior-Sheet_6
+  - first:
+      213: -5100863917353453704
+    second: Skeleton_Warrior-Sheet_7
+  - first:
+      213: -6069009701636567001
+    second: Skeleton_Warrior-Sheet_8
+  - first:
+      213: -7172212386086780211
+    second: Skeleton_Warrior-Sheet_9
+  - first:
+      213: 2321704070081464267
+    second: Skeleton_Warrior-Sheet_10
+  - first:
+      213: 7372487006611317280
+    second: Skeleton_Warrior-Sheet_11
+  - first:
+      213: -4389977079850698023
+    second: Skeleton_Warrior-Sheet_12
+  - first:
+      213: 6684054012544543093
+    second: Skeleton_Warrior-Sheet_13
+  - first:
+      213: -3733059784953260040
+    second: Skeleton_Warrior-Sheet_14
+  - first:
+      213: 6868177076176839535
+    second: Skeleton_Warrior-Sheet_15
+  - first:
+      213: 2306487458000242925
+    second: Skeleton_Warrior-Sheet_16
+  - first:
+      213: -6396222044953522577
+    second: Skeleton_Warrior-Sheet_17
+  - first:
+      213: 8494541786784653361
+    second: Skeleton_Warrior-Sheet_18
+  - first:
+      213: 5570493291257839976
+    second: Skeleton_Warrior-Sheet_19
+  - first:
+      213: 6941000946644355005
+    second: Skeleton_Warrior-Sheet_20
+  - first:
+      213: 2229347828428457895
+    second: Skeleton_Warrior-Sheet_21
+  - first:
+      213: -6504620962370601389
+    second: Skeleton_Warrior-Sheet_22
+  - first:
+      213: 7140751693236283513
+    second: Skeleton_Warrior-Sheet_23
+  - first:
+      213: 7513448876439589776
+    second: Skeleton_Warrior-Sheet_24
+  - first:
+      213: -3879646865477222442
+    second: Skeleton_Warrior-Sheet_25
+  - first:
+      213: -5048528896861171216
+    second: Skeleton_Warrior-Sheet_26
+  - first:
+      213: -5949012973533935293
+    second: Skeleton_Warrior-Sheet_27
+  - first:
+      213: -7980866787232787362
+    second: Skeleton_Warrior-Sheet_28
+  - first:
+      213: 6746486871487542874
+    second: Skeleton_Warrior-Sheet_29
+  - first:
+      213: -7566304522830529697
+    second: Skeleton_Warrior-Sheet_30
+  - first:
+      213: -3007108533385323757
+    second: Skeleton_Warrior-Sheet_31
+  - first:
+      213: 5042002423084735932
+    second: Skeleton_Warrior-Sheet_32
+  - first:
+      213: 8744336510436887853
+    second: Skeleton_Warrior-Sheet_33
+  - first:
+      213: -6164231861814612728
+    second: Skeleton_Warrior-Sheet_34
+  - first:
+      213: 8321978523517417068
+    second: Skeleton_Warrior-Sheet_35
+  - first:
+      213: -2047976441770955684
+    second: Skeleton_Warrior-Sheet_36
+  - first:
+      213: -1000622521106681835
+    second: Skeleton_Warrior-Sheet_37
+  - first:
+      213: -7833242208818280079
+    second: Skeleton_Warrior-Sheet_38
+  - first:
+      213: 3064310053950871980
+    second: Skeleton_Warrior-Sheet_39
+  - first:
+      213: 2750976140790799641
+    second: Skeleton_Warrior-Sheet_40
+  - first:
+      213: -6057581412443552621
+    second: Skeleton_Warrior-Sheet_41
+  - first:
+      213: 8836791413401637585
+    second: Skeleton_Warrior-Sheet_42
+  - first:
+      213: 5554722379731309896
+    second: Skeleton_Warrior-Sheet_43
+  - first:
+      213: -105225763622763490
+    second: Skeleton_Warrior-Sheet_44
+  - first:
+      213: -8588625545275625088
+    second: Skeleton_Warrior-Sheet_45
+  - first:
+      213: -5702705970805999750
+    second: Skeleton_Warrior-Sheet_46
+  - first:
+      213: 671084815609938864
+    second: Skeleton_Warrior-Sheet_47
+  - first:
+      213: -3705409553663855063
+    second: Skeleton_Warrior-Sheet_48
+  - first:
+      213: 7028927044964382726
+    second: Skeleton_Warrior-Sheet_49
+  - first:
+      213: -5146033834952003867
+    second: Skeleton_Warrior-Sheet_50
+  - first:
+      213: -2108671507531210375
+    second: Skeleton_Warrior-Sheet_51
+  - first:
+      213: -7047743329265681806
+    second: Skeleton_Warrior-Sheet_52
+  - first:
+      213: -878634987136295066
+    second: Skeleton_Warrior-Sheet_53
+  - first:
+      213: 4831013060271755230
+    second: Skeleton_Warrior-Sheet_54
+  - first:
+      213: -7655924358597185806
+    second: Skeleton_Warrior-Sheet_55
+  - first:
+      213: -2783888251784152255
+    second: Skeleton_Warrior-Sheet_56
+  - first:
+      213: 3245266416423409047
+    second: Skeleton_Warrior-Sheet_57
+  - first:
+      213: 6309118879192772842
+    second: Skeleton_Warrior-Sheet_58
+  - first:
+      213: 5856689563986140808
+    second: Skeleton_Warrior-Sheet_59
+  - first:
+      213: -1832642307490167646
+    second: Skeleton_Warrior-Sheet_60
+  - first:
+      213: 114462698314575130
+    second: Skeleton_Warrior-Sheet_61
+  - first:
+      213: 6390294112350067688
+    second: Skeleton_Warrior-Sheet_62
+  - first:
+      213: -6395402050081377530
+    second: Skeleton_Warrior-Sheet_63
+  - first:
+      213: 3955542978895138442
+    second: Skeleton_Warrior-Sheet_64
+  - first:
+      213: -5865053317022478561
+    second: Skeleton_Warrior-Sheet_65
+  - first:
+      213: 2367919956597361490
+    second: Skeleton_Warrior-Sheet_66
+  - first:
+      213: 5352758316452297096
+    second: Skeleton_Warrior-Sheet_67
+  - first:
+      213: -8222226671057846214
+    second: Skeleton_Warrior-Sheet_68
+  - first:
+      213: -4408859725983234500
+    second: Skeleton_Warrior-Sheet_69
+  - first:
+      213: -6285438767679743798
+    second: Skeleton_Warrior-Sheet_70
+  - first:
+      213: 9210507342309393287
+    second: Skeleton_Warrior-Sheet_71
+  - first:
+      213: -6676450982897681777
+    second: Skeleton_Warrior-Sheet_72
+  - first:
+      213: 1033953062816593254
+    second: Skeleton_Warrior-Sheet_73
+  - first:
+      213: -8437959680367883434
+    second: Skeleton_Warrior-Sheet_74
+  - first:
+      213: -6117903325218892926
+    second: Skeleton_Warrior-Sheet_75
+  - first:
+      213: 7556359079780419003
+    second: Skeleton_Warrior-Sheet_76
+  - first:
+      213: 72434390330506058
+    second: Skeleton_Warrior-Sheet_77
+  - first:
+      213: 5103970340459356031
+    second: Skeleton_Warrior-Sheet_78
+  - first:
+      213: -451628718534611725
+    second: Skeleton_Warrior-Sheet_79
+  - first:
+      213: 5699961626096934810
+    second: Skeleton_Warrior-Sheet_80
+  - first:
+      213: 3205044827311479113
+    second: Skeleton_Warrior-Sheet_81
+  - first:
+      213: -1481704986939643
+    second: Skeleton_Warrior-Sheet_82
+  - first:
+      213: -8120614895381199217
+    second: Skeleton_Warrior-Sheet_83
+  - first:
+      213: 1897656050489614306
+    second: Skeleton_Warrior-Sheet_84
+  - first:
+      213: -5065811532323863126
+    second: Skeleton_Warrior-Sheet_85
+  - first:
+      213: -7324960428779996205
+    second: Skeleton_Warrior-Sheet_86
+  - first:
+      213: 5146928606518330398
+    second: Skeleton_Warrior-Sheet_87
+  - first:
+      213: 6974534642733835668
+    second: Skeleton_Warrior-Sheet_88
+  - first:
+      213: -9111706058575554818
+    second: Skeleton_Warrior-Sheet_89
+  - first:
+      213: -2722872218227252658
+    second: Skeleton_Warrior-Sheet_90
+  - first:
+      213: -4734027819670493789
+    second: Skeleton_Warrior-Sheet_91
+  - first:
+      213: -7625825502005733980
+    second: Skeleton_Warrior-Sheet_92
+  - first:
+      213: 9131674142888138397
+    second: Skeleton_Warrior-Sheet_93
+  - first:
+      213: -8005008422839853267
+    second: Skeleton_Warrior-Sheet_94
+  - first:
+      213: 2557490239219108622
+    second: Skeleton_Warrior-Sheet_95
+  - first:
+      213: -6970103483788835513
+    second: Skeleton_Warrior-Sheet_96
+  - first:
+      213: -7296668671365893993
+    second: Skeleton_Warrior-Sheet_97
+  - first:
+      213: -2904579429496391196
+    second: Skeleton_Warrior-Sheet_98
+  - first:
+      213: 6359732793896332945
+    second: Skeleton_Warrior-Sheet_99
+  - first:
+      213: -5846363540929747924
+    second: Skeleton_Warrior-Sheet_100
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 1040
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 0ef3834ff0c4ddac0800000000000000
+      internalID: -3828820476789506080
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_1
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 1040
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: dea0761e41e55b0d0800000000000000
+      internalID: -3407714099261928723
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_2
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 1040
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c9189dd1420df6e70800000000000000
+      internalID: 9110729424731996572
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_3
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 1040
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: aa8575edfbea3cca0800000000000000
+      internalID: -5997758139635115862
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_4
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5f3e0018f47bf9f30800000000000000
+      internalID: 4584584497781072885
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_5
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 92f8c3ba6b9c44a40800000000000000
+      internalID: 5351624043617095465
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_6
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 728a4792df44e3e40800000000000000
+      internalID: 5638019637627365415
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_7
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8773a8eea471639b0800000000000000
+      internalID: -5100863917353453704
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_8
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7209d83d4db86cba0800000000000000
+      internalID: -6069009701636567001
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_9
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: dc204a9b5de277c90800000000000000
+      internalID: -7172212386086780211
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_10
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: bc7c8c20d89583020800000000000000
+      internalID: 2321704070081464267
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_11
+      rect:
+        serializedVersion: 2
+        x: 770
+        y: 960
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 02220441fd5505660800000000000000
+      internalID: 7372487006611317280
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_12
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 9da746fda1ba313c0800000000000000
+      internalID: -4389977079850698023
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_13
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 579ed35f5b782cc50800000000000000
+      internalID: 6684054012544543093
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_14
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8f7909877e1813cc0800000000000000
+      internalID: -3733059784953260040
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_15
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f63600069aaa05f50800000000000000
+      internalID: 6868177076176839535
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_16
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: de88ffc6f1a420020800000000000000
+      internalID: 2306487458000242925
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_17
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f6ec50250fd0c37a0800000000000000
+      internalID: -6396222044953522577
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_18
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 130e203cfbca2e570800000000000000
+      internalID: 8494541786784653361
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_19
+      rect:
+        serializedVersion: 2
+        x: 770
+        y: 880
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 861ce19722e5e4d40800000000000000
+      internalID: 5570493291257839976
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_20
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 800
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: db703620693635060800000000000000
+      internalID: 6941000946644355005
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_21
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 800
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7a74442d90c30fe10800000000000000
+      internalID: 2229347828428457895
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_22
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 800
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 35e375b92b1fab5a0800000000000000
+      internalID: -6504620962370601389
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_23
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 800
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 9782e98e4db091360800000000000000
+      internalID: 7140751693236283513
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_24
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 720
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 0935d36f1f1254860800000000000000
+      internalID: 7513448876439589776
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_25
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 720
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 6dfb5492bb9b82ac0800000000000000
+      internalID: -3879646865477222442
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_26
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 720
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 0f19b4077b500f9b0800000000000000
+      internalID: -5048528896861171216
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_27
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 720
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 349c154483cd07da0800000000000000
+      internalID: -5949012973533935293
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_28
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e54d64301f34e3190800000000000000
+      internalID: -7980866787232787362
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_29
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a56f9d0b01650ad50800000000000000
+      internalID: 6746486871487542874
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_30
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f5b314edf161ff690800000000000000
+      internalID: -7566304522830529697
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_31
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 31b9582a8ba9446d0800000000000000
+      internalID: -3007108533385323757
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_32
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: cbddf987d7ac8f540800000000000000
+      internalID: 5042002423084735932
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_33
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: d2dc11d0abf1a5970800000000000000
+      internalID: 8744336510436887853
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_34
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 80d256bf7cf347aa0800000000000000
+      internalID: -6164231861814612728
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_35
+      rect:
+        serializedVersion: 2
+        x: 770
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c667faa106b9d7370800000000000000
+      internalID: 8321978523517417068
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_36
+      rect:
+        serializedVersion: 2
+        x: 880
+        y: 640
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c5cafdfd6402493e0800000000000000
+      internalID: -2047976441770955684
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_37
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5103e2b5e131d12f0800000000000000
+      internalID: -1000622521106681835
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_38
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 1794acf96bbba4390800000000000000
+      internalID: -7833242208818280079
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_39
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ca9566732cd968a20800000000000000
+      internalID: 3064310053950871980
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_40
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 91d1969893e6d2620800000000000000
+      internalID: 2750976140790799641
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_41
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 3940b41ccc52feba0800000000000000
+      internalID: -6057581412443552621
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_42
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 1d2d60e98f692aa70800000000000000
+      internalID: 8836791413401637585
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_43
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8451ccdf296561d40800000000000000
+      internalID: 5554722379731309896
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_44
+      rect:
+        serializedVersion: 2
+        x: 770
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: e14cb0ab9b92a8ef0800000000000000
+      internalID: -105225763622763490
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_45
+      rect:
+        serializedVersion: 2
+        x: 880
+        y: 560
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 081300132921fc880800000000000000
+      internalID: -8588625545275625088
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_46
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a77fb9f322bebd0b0800000000000000
+      internalID: -5702705970805999750
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_47
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 0b3c690951c205900800000000000000
+      internalID: 671084815609938864
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_48
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 926f68e94adb39cc0800000000000000
+      internalID: -3705409553663855063
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_49
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 608fc3318e3cb8160800000000000000
+      internalID: 7028927044964382726
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_50
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 5ee6b81fd7d9598b0800000000000000
+      internalID: -5146033834952003867
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_51
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 9716d95af6e7cb2e0800000000000000
+      internalID: -2108671507531210375
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_52
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 27a7df658c2613e90800000000000000
+      internalID: -7047743329265681806
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_53
+      rect:
+        serializedVersion: 2
+        x: 770
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 66fd28862267ec3f0800000000000000
+      internalID: -878634987136295066
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_54
+      rect:
+        serializedVersion: 2
+        x: 880
+        y: 480
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: edf45c258c43b0340800000000000000
+      internalID: 4831013060271755230
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_55
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 2feed82db51b0c590800000000000000
+      internalID: -7655924358597185806
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_56
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 14bb50a7264ad59d0800000000000000
+      internalID: -2783888251784152255
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_57
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7951c609c90890d20800000000000000
+      internalID: 3245266416423409047
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_58
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ae0fef7813e7e8750800000000000000
+      internalID: 6309118879192772842
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_59
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 88e912dd024274150800000000000000
+      internalID: 5856689563986140808
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_60
+      rect:
+        serializedVersion: 2
+        x: 550
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 2a442b5f7852196e0800000000000000
+      internalID: -1832642307490167646
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_61
+      rect:
+        serializedVersion: 2
+        x: 660
+        y: 400
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a1da219b737a69100800000000000000
+      internalID: 114462698314575130
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_62
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 320
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 8eb55e053a2eea850800000000000000
+      internalID: 6390294112350067688
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_63
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 320
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 603381148b7fe37a0800000000000000
+      internalID: -6395402050081377530
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_64
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 320
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a8ec5d6c169e4e630800000000000000
+      internalID: 3955542978895138442
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_65
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 320
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f1f062225152b9ea0800000000000000
+      internalID: -5865053317022478561
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_66
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 320
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 25b4b8d97aa8cd020800000000000000
+      internalID: 2367919956597361490
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_67
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 240
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 88938a42451d84a40800000000000000
+      internalID: 5352758316452297096
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_68
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 240
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: a30cad8e768c4ed80800000000000000
+      internalID: -8222226671057846214
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_69
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 240
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: c364e38307590d2c0800000000000000
+      internalID: -4408859725983234500
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_70
+      rect:
+        serializedVersion: 2
+        x: 330
+        y: 240
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: ac8daf21eb2a5c8a0800000000000000
+      internalID: -6285438767679743798
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_71
+      rect:
+        serializedVersion: 2
+        x: 440
+        y: 240
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 7838a73e0ab42df70800000000000000
+      internalID: 9210507342309393287
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_72
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 160
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: f8a7314543b7853a0800000000000000
+      internalID: -6676450982897681777
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_73
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 80
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 6653c9f15d6595e00800000000000000
+      internalID: 1033953062816593254
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_74
+      rect:
+        serializedVersion: 2
+        x: 110
+        y: 80
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 65b8a9e706856ea80800000000000000
+      internalID: -8437959680367883434
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_75
+      rect:
+        serializedVersion: 2
+        x: 220
+        y: 80
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 283952af657d81ba0800000000000000
+      internalID: -6117903325218892926
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Skeleton_Warrior-Sheet_76
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 110
+        height: 80
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: bb50c993c849dd860800000000000000
+      internalID: 7556359079780419003
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 3fb27cb66b1075c4487a8a4fb187a6ec
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":9.0,"y":14.0},"gridSpriteSize":{"x":110.0,"y":80.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
+    nameFileIdTable:
+      Skeleton_Warrior-Sheet_0: -3828820476789506080
+      Skeleton_Warrior-Sheet_1: -3407714099261928723
+      Skeleton_Warrior-Sheet_10: 2321704070081464267
+      Skeleton_Warrior-Sheet_11: 7372487006611317280
+      Skeleton_Warrior-Sheet_12: -4389977079850698023
+      Skeleton_Warrior-Sheet_13: 6684054012544543093
+      Skeleton_Warrior-Sheet_14: -3733059784953260040
+      Skeleton_Warrior-Sheet_15: 6868177076176839535
+      Skeleton_Warrior-Sheet_16: 2306487458000242925
+      Skeleton_Warrior-Sheet_17: -6396222044953522577
+      Skeleton_Warrior-Sheet_18: 8494541786784653361
+      Skeleton_Warrior-Sheet_19: 5570493291257839976
+      Skeleton_Warrior-Sheet_2: 9110729424731996572
+      Skeleton_Warrior-Sheet_20: 6941000946644355005
+      Skeleton_Warrior-Sheet_21: 2229347828428457895
+      Skeleton_Warrior-Sheet_22: -6504620962370601389
+      Skeleton_Warrior-Sheet_23: 7140751693236283513
+      Skeleton_Warrior-Sheet_24: 7513448876439589776
+      Skeleton_Warrior-Sheet_25: -3879646865477222442
+      Skeleton_Warrior-Sheet_26: -5048528896861171216
+      Skeleton_Warrior-Sheet_27: -5949012973533935293
+      Skeleton_Warrior-Sheet_28: -7980866787232787362
+      Skeleton_Warrior-Sheet_29: 6746486871487542874
+      Skeleton_Warrior-Sheet_3: -5997758139635115862
+      Skeleton_Warrior-Sheet_30: -7566304522830529697
+      Skeleton_Warrior-Sheet_31: -3007108533385323757
+      Skeleton_Warrior-Sheet_32: 5042002423084735932
+      Skeleton_Warrior-Sheet_33: 8744336510436887853
+      Skeleton_Warrior-Sheet_34: -6164231861814612728
+      Skeleton_Warrior-Sheet_35: 8321978523517417068
+      Skeleton_Warrior-Sheet_36: -2047976441770955684
+      Skeleton_Warrior-Sheet_37: -1000622521106681835
+      Skeleton_Warrior-Sheet_38: -7833242208818280079
+      Skeleton_Warrior-Sheet_39: 3064310053950871980
+      Skeleton_Warrior-Sheet_4: 4584584497781072885
+      Skeleton_Warrior-Sheet_40: 2750976140790799641
+      Skeleton_Warrior-Sheet_41: -6057581412443552621
+      Skeleton_Warrior-Sheet_42: 8836791413401637585
+      Skeleton_Warrior-Sheet_43: 5554722379731309896
+      Skeleton_Warrior-Sheet_44: -105225763622763490
+      Skeleton_Warrior-Sheet_45: -8588625545275625088
+      Skeleton_Warrior-Sheet_46: -5702705970805999750
+      Skeleton_Warrior-Sheet_47: 671084815609938864
+      Skeleton_Warrior-Sheet_48: -3705409553663855063
+      Skeleton_Warrior-Sheet_49: 7028927044964382726
+      Skeleton_Warrior-Sheet_5: 5351624043617095465
+      Skeleton_Warrior-Sheet_50: -5146033834952003867
+      Skeleton_Warrior-Sheet_51: -2108671507531210375
+      Skeleton_Warrior-Sheet_52: -7047743329265681806
+      Skeleton_Warrior-Sheet_53: -878634987136295066
+      Skeleton_Warrior-Sheet_54: 4831013060271755230
+      Skeleton_Warrior-Sheet_55: -7655924358597185806
+      Skeleton_Warrior-Sheet_56: -2783888251784152255
+      Skeleton_Warrior-Sheet_57: 3245266416423409047
+      Skeleton_Warrior-Sheet_58: 6309118879192772842
+      Skeleton_Warrior-Sheet_59: 5856689563986140808
+      Skeleton_Warrior-Sheet_6: 5638019637627365415
+      Skeleton_Warrior-Sheet_60: -1832642307490167646
+      Skeleton_Warrior-Sheet_61: 114462698314575130
+      Skeleton_Warrior-Sheet_62: 6390294112350067688
+      Skeleton_Warrior-Sheet_63: -6395402050081377530
+      Skeleton_Warrior-Sheet_64: 3955542978895138442
+      Skeleton_Warrior-Sheet_65: -5865053317022478561
+      Skeleton_Warrior-Sheet_66: 2367919956597361490
+      Skeleton_Warrior-Sheet_67: 5352758316452297096
+      Skeleton_Warrior-Sheet_68: -8222226671057846214
+      Skeleton_Warrior-Sheet_69: -4408859725983234500
+      Skeleton_Warrior-Sheet_7: -5100863917353453704
+      Skeleton_Warrior-Sheet_70: -6285438767679743798
+      Skeleton_Warrior-Sheet_71: 9210507342309393287
+      Skeleton_Warrior-Sheet_72: -6676450982897681777
+      Skeleton_Warrior-Sheet_73: 1033953062816593254
+      Skeleton_Warrior-Sheet_74: -8437959680367883434
+      Skeleton_Warrior-Sheet_75: -6117903325218892926
+      Skeleton_Warrior-Sheet_76: 7556359079780419003
+      Skeleton_Warrior-Sheet_8: -6069009701636567001
+      Skeleton_Warrior-Sheet_9: -7172212386086780211
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,6 +14,7 @@
     "com.unity.inputsystem": "1.17.0",
     "com.unity.ml-agents": "4.0.1",
     "com.unity.multiplayer.center": "1.0.1",
+    "com.unity.recorder": "5.1.5",
     "com.unity.render-pipelines.universal": "17.3.0",
     "com.unity.test-framework": "1.6.0",
     "com.unity.timeline": "1.8.10",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -112,6 +112,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.bindings.openimageio": {
+      "version": "1.0.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.collections": "1.2.4"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.8.27",
       "depth": 2,
@@ -226,6 +235,17 @@
       "depth": 2,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.recorder": {
+      "version": "5.1.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.timeline": "1.8.7",
+        "com.unity.collections": "1.2.4",
+        "com.unity.bindings.openimageio": "1.0.2"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {


### PR DESCRIPTION
## Summary
- **MeleeSkeleton**: Melee enemy with Idle/Chase/Attack states. Attack damage is driven by a `MeleeHit()` animation event at the swing frame. Includes hit stun, knockback resistance, freeze rotation, and full rewind support.
- **GhostEnemy**: Floating enemy that chases the player and periodically teleports using PhaseOut/PhaseIn animations. Raycasts to the ground surface at the landing spot to avoid clipping. Includes contact damage, hit stun, and full rewind support (animator state, collider state, teleport cooldown).



## Test plan
- [ ] MeleeSkeleton idles, chases, and attacks at melee range
- [ ] `MeleeHit()` animation event deals damage at the correct swing frame
- [ ] MeleeSkeleton takes knockback, plays hit animation, and dies without falling through the floor
- [ ] GhostEnemy chases player and periodically phases out, teleports near player, phases in
- [ ] Ghost teleports to ground surface (no clipping underground)
- [ ] Ghost collider is disabled during teleport (no contact damage while invisible)
- [ ] `GhostDealDamage()` animation event fires at the correct attack frame
- [ ] Both enemies restore correct position and animator state on rewind