### PR TITLE
Add PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Tech lead oversight
+* @ethanr04
+
+# Spritework
+/Assets/Sprites/ @OliverTchum
+
+# Animations
+/Assets/Animations/ @OliverTchum
+
+# Time rewind
+/Assets/Scripts/TimeRewind/ @qc23151
+
+# Enemy scripts
+/Assets/Scripts/EnemyLogic/ @yi23484
+
+# Tutorial work
+/Assets/Scripts/Tutorial/ @megan-pa
+
+# UI work
+/Assets/Scripts/UI Scripts/ @megan-pa
+
+# Player movement
+/Assets/Scripts/Player* @pabloapca
+
+# AI enemy scripts
+/Assets/Scripts/AdvancedEnemyLogic/ @ethanr04

--- a/.github/pr_template.md
+++ b/.github/pr_template.md
@@ -1,0 +1,27 @@
+## Type of Change
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Both
+- [ ] Other (please specify)
+
+## What's been done
+- 
+- 
+
+## Screenshot(s) / Video(s)
+
+
+## How it's been done
+-
+-
+
+## What's next
+- 
+- 
+
+## Related Issues
+-
+
+## Notes for Reviewers
+-
+-


### PR DESCRIPTION
Just a quick one - added a PR template and CODEOWNERS. Feel free to add to this, or create more specific templates.
CODEOWNERS is responsible for automatically assigning reviewers for PRs when certain files are changed. We should each get assigned if anyone edits the things we have worked on the most. Feel free to add to this too.